### PR TITLE
feature/etyley_sce_v9

### DIFF
--- a/lardataalg/DetectorInfo/DetectorProperties.h
+++ b/lardataalg/DetectorInfo/DetectorProperties.h
@@ -49,7 +49,9 @@ namespace detinfo {
 
     /// dQ/dX in electrons/cm, returns dE/dX in MeV/cm.
     virtual double BirksCorrection(double dQdX) const = 0;
+    virtual double BirksCorrection(double dQdX, double EField) const = 0;
     virtual double ModBoxCorrection(double dQdX) const = 0;
+    virtual double ModBoxCorrection(double dQdX, double EField) const = 0;
 
     /**
      * @brief Returns the attenuation constant for ionization electrons.

--- a/lardataalg/DetectorInfo/DetectorPropertiesData.cc
+++ b/lardataalg/DetectorInfo/DetectorPropertiesData.cc
@@ -28,13 +28,23 @@ detinfo::DetectorPropertiesData::DriftVelocity(double const efield, double const
 double
 detinfo::DetectorPropertiesData::BirksCorrection(double const dQdX) const
 {
-  return fProperties.BirksCorrection(dQdX);
+  return fProperties.BirksCorrection(dQdX, Efield());
+}
+double
+detinfo::DetectorPropertiesData::BirksCorrection(double const dQdX, double const EField) const
+{
+  return fProperties.BirksCorrection(dQdX, EField);
 }
 
 double
 detinfo::DetectorPropertiesData::ModBoxCorrection(double const dQdX) const
 {
-  return fProperties.ModBoxCorrection(dQdX);
+  return fProperties.ModBoxCorrection(dQdX, Efield());
+}
+double
+detinfo::DetectorPropertiesData::ModBoxCorrection(double const dQdX, double const EField) const
+{
+  return fProperties.ModBoxCorrection(dQdX, EField);
 }
 
 double

--- a/lardataalg/DetectorInfo/DetectorPropertiesData.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesData.h
@@ -22,7 +22,9 @@ namespace detinfo {
 
     /// dQ/dX in electrons/cm, returns dE/dX in MeV/cm.
     double BirksCorrection(double dQdX) const;
+    double BirksCorrection(double dQdX, double EField) const;
     double ModBoxCorrection(double dQdX) const;
+    double ModBoxCorrection(double dQdX, double EField) const;
 
     double ElectronLifetime() const;
 

--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
@@ -278,9 +278,15 @@ namespace detinfo {
   // parameters:
   //  dQdX in electrons/cm, charge (amplitude or integral obtained) divided by
   //         effective pitch for a given 3D track.
+  //  Electric Field in the drift region in KV/cm/
   // returns dEdX in MeV/cm
   double
   DetectorPropertiesStandard::BirksCorrection(double dQdx) const
+  {
+    return BirksCorrection(dQdx, Efield());
+  }
+  double
+  DetectorPropertiesStandard::BirksCorrection(double dQdx, double E_field) const
   {
     // Correction for charge quenching using parameterization from
     // S.Amoruso et al., NIM A 523 (2004) 275
@@ -289,7 +295,6 @@ namespace detinfo {
     double K3t = util::kRecombk;                           // in KV/cm*(g/cm^2)/MeV
     double const rho = Density();                          // LAr density in g/cm^3
     constexpr double Wion = 1000. / util::kGeVToElectrons; // 23.6 eV = 1e, Wion in MeV/e
-    double const E_field = Efield(); // Electric Field in the drift region in KV/cm
     K3t /= rho;                      // KV/MeV
     double const dEdx = dQdx / (A3t / Wion - K3t / E_field * dQdx); // MeV/cm
 
@@ -301,11 +306,15 @@ namespace detinfo {
   double
   DetectorPropertiesStandard::ModBoxCorrection(double dQdx) const
   {
+    return ModBoxCorrection(dQdx, Efield());
+  }
+  double
+  DetectorPropertiesStandard::ModBoxCorrection(double dQdx, double E_field) const
+  {
     // Modified Box model correction has better behavior than the Birks
     // correction at high values of dQ/dx.
     double const rho = Density();                          // LAr density in g/cm^3
     constexpr double Wion = 1000. / util::kGeVToElectrons; // 23.6 eV = 1e, Wion in MeV/e
-    double const E_field = Efield(); // Electric Field in the drift region in KV/cm
     double const Beta = util::kModBoxB / (rho * E_field);
     constexpr double Alpha = util::kModBoxA;
     double const dEdx = (exp(Beta * Wion * dQdx) - Alpha) / Beta;

--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
@@ -135,7 +135,9 @@ namespace detinfo {
 
     /// dQ/dX in electrons/cm, returns dE/dX in MeV/cm.
     double BirksCorrection(double dQdX) const override;
+    double BirksCorrection(double dQdX, double EField) const override;
     double ModBoxCorrection(double dQdX) const override;
+    double ModBoxCorrection(double dQdX, double EField) const override;
 
     double
     ElectronLifetime() const override


### PR DESCRIPTION
Changed EField to be a input parameter for recombination calculations in detector properties. Previously this calculation used the global electric field but this change allows for passing of a local electric field in the case of non-uniformity (e.g. space charge). Note the lardata PR required by this for ArgoNeut.