### PR TITLE
Facilitate call to DetectorClocksStandard::DataFor() [1/2]

### DIFF
--- a/lardataalg/DetectorInfo/DetectorClocksStandardDataFor.h
+++ b/lardataalg/DetectorInfo/DetectorClocksStandardDataFor.h
@@ -1,0 +1,93 @@
+/**
+ * @file   lardataalg/DetectorInfo/DetectorClocksStandardDataFor.h
+ * @brief  Helper to get clocks data from `detinfo::DetectorClocksStandard`.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   October 14, 2020
+ * 
+ * This library is header-only.
+ */
+
+#ifndef LARDATAALG_DETECTORINFO_DETECTORCLOCKSSTANDARDDATAFOR_H
+#define LARDATAALG_DETECTORINFO_DETECTORCLOCKSSTANDARDDATAFOR_H
+
+// LArSoft libraries
+#include "lardataalg/DetectorInfo/DetectorClocksStandardTriggerLoader.h"
+#include "lardataobj/RawData/TriggerData.h" // raw::Trigger
+
+// framework libraries
+#include "canvas/Utilities/InputTag.h"
+#include "cetlib_except/exception.h"
+
+// C++ standard libraries
+#include <optional>
+#include <vector>
+
+namespace detinfo {
+
+  /**
+   * @brief Returns `DetectorClocksData` tuned on the specified `event`.
+   * @tparam Event type of framework event
+   * @param detClocks service provider generating the data
+   * @param event event to read information from
+   * @return `DetectorClocksData` tuned on the specified `event`
+   * 
+   * This function takes care to extract all what is needed by
+   * `DetectorClocksStandard` service provider in order to provide data for
+   * the event.
+   * 
+   * Example:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * detinfo::DetectorClocksStandard const detClocks
+   *   { config.get<fhicl::ParameterSet>("services.DetectorClocksService") };
+   * 
+   * for (gallery::Event event(inputFiles); !event.atEnd(); event.next()) {
+   *   
+   *   detinfo::DetectorClocksData const clockData
+   *     = detinfo::detectorClocksStandardDataFor(detClocks, event);
+   *   
+   *   auto const triggerTime = clockData.TriggerTime();
+   *   
+   *   // etc...
+   *   
+   * } // for
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * 
+   * 
+   * Requirements
+   * -------------
+   * 
+   * The implementation is effectively dependent on the framework managing the
+   * `event`, but it is not _formally_ dependent on any implementation.
+   * Assumptions include everything that is required by other helper functions
+   * like `detinfo::trigger_times_for_event()` and
+   * `detinfo::g4ref_time_for_event()` (mostly, support for a call like
+   * `Event::getByLabel(art::InputTag, Event::HandleT<T>)`).
+   */
+  template <typename Event>
+  detinfo::DetectorClocksData detectorClocksStandardDataFor(
+    detinfo::DetectorClocksStandard const& detClocks,
+    Event const& event
+  ) {
+
+    auto const& config_values = detClocks.ConfigValues();
+    // Trigger times
+    double trig_time{config_values[kDefaultTrigTime]};
+    double beam_time{config_values[kDefaultBeamTime]};
+    if (auto times = trigger_times_for_event(detClocks.TrigModuleName(), event)) {
+      std::tie(trig_time, beam_time) = *times;
+    }
+
+    double g4_ref_time{config_values[kG4RefTime]};
+    if (auto sim_trig_time = g4ref_time_for_event(detClocks.G4RefCorrTrigModuleName(), event)) {
+      g4_ref_time -= trig_time;
+      g4_ref_time += *sim_trig_time;
+    }
+    return detClocks.DataFor(g4_ref_time, trig_time, beam_time);
+  } // detinfo::detectorClocksStandardDataFor()
+
+
+} // namespace detinfo
+
+
+
+#endif // LARDATA_DETECTORINFO_DETECTORCLOCKSSTANDARDTRIGGERLOADER_H


### PR DESCRIPTION
This is part of a group of pull requests that also include pull request LArSoft/lardata#11.

The preparation work needed to get a `detinfo::DetectorClocksData` from a `detinfo::DetectorClocksStandard` service provider is non-trivial (see the implementation of the old `detinfo::DetectorClocksServiceStandard::DataFor(art::Event const&)`).
This preparation is performed for the lucky _art_ user by `detinfo::DetectorClocksServiceStandard`, all other users need to make it on their own.

I propose delegating that initialisation to a helper function crafted to work in both _art_ and _gallery_ frameworks, and in general in any environment with an object exposing a minimal `art::Event`-like interface.

This implementation is a proposal for the described feature. The preparation code has been moved from `detinfo::DetectorClocksServiceStandard::DataFor()` into an helper function, and `detinfo::DetectorClocksServiceStandard::DataFor()` now delegates to it. The documentation of the helper function show how it can be used to obtain a `detinfo::DetectorClocksData` record within _gallery_.
Other details:
* testing: I am satisfactorily using this implementation in my local area for some (_gallery_) analysis, and this implementation passes all LArSoft unit tests;
* the implementation of `detinfo::DetectorClocksServiceStandard::DataFor()` has moved into the implementation file to reduce the header inclusion bloating;
* ~note that this branch also includes the commits of the workaround of issue #25077 (pull request #15) which I discovered working on this.~ _apparently it does not, mysteries of GitFlow_

I request a review of the feature and I propose merging provided that a positive outcome is reached.

