### PR TITLE
DetectorTimings support for tick-to-tick conversions.

### DIFF
--- a/test/DetectorInfo/DetectorClocksStandard_test.cc
+++ b/test/DetectorInfo/DetectorClocksStandard_test.cc
@@ -85,7 +85,7 @@ main(int argc, char const** argv)
   auto const* detClocks = TestEnv.Provider<detinfo::DetectorClocks>();
   auto const& detClocksData = detClocks->DataForJob();
   mf::LogVerbatim("clocks_test")
-    << "TPC clock period: " << detClocksData.TPCClock().FramePeriod() << " us";
+    << "TPC clock frame: " << detClocksData.TPCClock().FramePeriod() << " us";
 
   detClocksData.debugReport(std::cout);
 


### PR DESCRIPTION
`detinfo::DetectorTimings::toTick()` now supports tick type arguments together with time type arguments.