### PR TITLE
Fix larproperties.fcl

### DIFF
--- a/lardataalg/DetectorInfo/larproperties.fcl
+++ b/lardataalg/DetectorInfo/larproperties.fcl
@@ -18,8 +18,8 @@ standard_properties:
 
  # Optical properties
  # Fast and slow scintillation emission spectra, from [J Chem Phys vol 91 (1989) 1469]
- FastScintEnergies:    [ 6.0,  6.7,  7.1,  7.4,  7.7, 7.9,  8.1,  8.4,  8.5,  8.6,  8.8,  9.0,  9.1,  9.4,  9.8,  10.4,  10.7]
- SlowScintEnergies:    [ 6.0,  6.7,  7.1,  7.4,  7.7, 7.9,  8.1,  8.4,  8.5,  8.6,  8.8,  9.0,  9.1,  9.4,  9.8,  10.4,  10.7]
+ FastScintEnergies:    [ 7.2,  7.9,  8.3,  8.6,  8.9,  9.1,  9.3,  9.6,  9.7,  9.8,  10,  10.2,  10.3,  10.6,  11,  11.6,  11.9]
+ SlowScintEnergies:    [ 7.2,  7.9,  8.3,  8.6,  8.9,  9.1,  9.3,  9.6,  9.7,  9.8,  10,  10.2,  10.3,  10.6,  11,  11.6,  11.9]
  FastScintSpectrum:    [ 0.0,  0.04, 0.12, 0.27, 0.44, 0.62, 0.80, 0.91, 0.92, 0.85, 0.70, 0.50, 0.31, 0.13, 0.04,  0.01, 0.0]
  SlowScintSpectrum:    [ 0.0,  0.04, 0.12, 0.27, 0.44, 0.62, 0.80, 0.91, 0.92, 0.85, 0.70, 0.50, 0.31, 0.13, 0.04,  0.01, 0.0]
  ScintResolutionScale: 1.     # resolution factor used by G4 scintillation


### PR DESCRIPTION
Current FastScintEnergies and SlowScintEnergies seem to correspond to Kr (emission peak at ~8.5 eV -> 146 nm) instead of Argon (emission peak at ~9.7 eV -> 128 nm). There is no need to change the shape of the spectra (FastScintSpectrum/SlowScintSpectrum) but energies need to be shifted in ~1.2 eV to larger values (which is the proposed change).