### PR TITLE
Method in util::quantities::Quantity made const

### DIFF
--- a/lardataalg/Utilities/intervals.h
+++ b/lardataalg/Utilities/intervals.h
@@ -413,7 +413,7 @@ namespace util::quantities {
 
       /// Convert this interval into the specified one.
       template <typename IV>
-      IV convertInto() { return IV(*this); }
+      constexpr IV convertInto() const { return IV(*this); }
 
       /**
        * @brief Returns a new interval initialized with the specified value.
@@ -977,7 +977,7 @@ namespace util::quantities {
 
       /// Convert this interval into the specified one.
       template <typename PT>
-      std::enable_if_t<is_point_v<PT>, PT> convertInto() { return PT(*this); }
+      constexpr std::enable_if_t<is_point_v<PT>, PT> convertInto() const { return PT(*this); }
 
       /**
        * @brief Returns a new point initialized with the specified value.

--- a/lardataalg/Utilities/quantities.h
+++ b/lardataalg/Utilities/quantities.h
@@ -824,7 +824,7 @@ namespace util::quantities {
 
       /// Convert this quantity into the specified one.
       template <typename OQ>
-      OQ convertInto() { return OQ(*this); }
+      constexpr OQ convertInto() const { return OQ(*this); }
 
 
       /**


### PR DESCRIPTION
A few methods were non-const for an oversight (likely from cut&paste).

GitHub edit, counting on C.I.