### PR TITLE
Remove unused comparisons/conversions and Boost test cleanup

### DIFF
--- a/lardataalg/Utilities/intervals.h
+++ b/lardataalg/Utilities/intervals.h
@@ -481,6 +481,10 @@ namespace util::quantities {
       (Quantity<Args...> const a, Interval<Q, Cat> const b) noexcept
       { return b < a; }
 
+    /// @}
+    // -- END Comparison operations --------------------------------------------
+
+
     // -- BEGIN Arithmetic operations ------------------------------------------
     /**
      * @name Arithmetic operations on `Quantity`
@@ -905,6 +909,8 @@ namespace util::quantities {
       (Quantity<Args...> const a, Point<Q, Cat, IV> const b) noexcept
       { return b < a; }
 
+    /// @}
+    // -- END Comparison operations --------------------------------------------
 
     // -- BEGIN Arithmetic operations ------------------------------------------
     /**

--- a/lardataalg/Utilities/intervals.h
+++ b/lardataalg/Utilities/intervals.h
@@ -17,30 +17,6 @@
 #include <ostream>
 #include <type_traits> // std::enable_if_t<>, ...
 
-/**
- * @def LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
- * @brief Enable implicit conversions of `Point` and `Interval` into `value_t`.
- * @see LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
- *
- * This is likely going to break a number of features, and enabling it should
- * be followed by intense scrutiny of the tests.
- */
-#undef LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
-
-/**
- * @def LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
- * @brief Enable comparisons of `Point` and `Interval` with `value_t`.
- * @see LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
- *
- * This is likely going to break some code, and it is dangerous in that a
- * statement like `t > 5` does not really make sure `5` is the right unit.
- * With this feature disabled (which is recommended), the same comparison would
- * be written `t > 5_ms`, thus ensuring the unit is known (this comes with the
- * hassle of `using namespace util::quantities::time_literals` or such).
- */
-#undef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-
-
 namespace util::quantities {
 
   /// Category type for intervals and point not belonging to any category.
@@ -225,10 +201,7 @@ namespace util::quantities {
       using quantity_t::value;
 
       /// Conversion to the base quantity.
-#ifndef LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
-      explicit
-#endif // !LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
-      constexpr operator value_t() const
+      explicit constexpr operator value_t() const
         { return value(); }
 
 
@@ -508,144 +481,6 @@ namespace util::quantities {
       (Quantity<Args...> const a, Interval<Q, Cat> const b) noexcept
       { return b < a; }
 
-
-    /*
-     * To refrain the wild matching of every type with `V`, and still retain
-     * the ability to compare to e.g. an integer rather than a double, instead
-     * of forcing `V` and `T` to match, we ask `V` to be _implicitly_
-     * convertible into `T`.
-     * In particular, any requirement must exclude `Quantity` types from
-     * matching to `V`, or the interplay with the `Quantity` vs. `Quantity`
-     * comparisons will be messy at best. Currently `Quantity` converts to
-     * its `value_t` only via explicit conversion. If this is going to change,
-     * the `V` to `T` matching requirement must become stricter, e.g.
-     * `std::is_arithmetic_v<V>`.
-     */
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator== (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() == value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator== (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv == value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator!= (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() != value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator!= (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv != value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator<= (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() <= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator<= (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv >= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator< (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() < value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator< (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv > value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator>= (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() >= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator>= (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv <= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator> (Interval<Q, Cat> const iv, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv.quantity() > value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename T>
-    constexpr std::enable_if_t
-      <std::is_convertible_v<T, typename Interval<Q, Cat>::value_t>, bool>
-    operator> (T const value, Interval<Q, Cat> const iv) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return iv < value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-
-    /// @}
-    // -- END Comparison operations --------------------------------------------
-
-
     // -- BEGIN Arithmetic operations ------------------------------------------
     /**
      * @name Arithmetic operations on `Quantity`
@@ -817,10 +652,7 @@ namespace util::quantities {
       using quantity_t::value;
 
       /// Conversion to the base quantity.
-#ifndef LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
-      explicit
-#endif // LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION
-      constexpr operator value_t() const
+      explicit constexpr operator value_t() const
         { return value(); }
 
 
@@ -1072,155 +904,6 @@ namespace util::quantities {
     constexpr bool operator>
       (Quantity<Args...> const a, Point<Q, Cat, IV> const b) noexcept
       { return b < a; }
-
-
-    /*
-     * To refrain the wild matching of every type with `V`, and still retain
-     * the ability to compare to e.g. an integer rather than a double, instead
-     * of forcing `V` and `T` to match, we ask `V` to be _implicitly_
-     * convertible into `T`.
-     * In particular, any requirement must exclude `Quantity` types from
-     * matching to `V`, or the interplay with the `Quantity` vs. `Quantity`
-     * comparisons will be messy at best. Currently `Quantity` converts to
-     * its `value_t` only via explicit conversion. If this is going to change,
-     * the `V` to `T` matching requirement must become stricter, e.g.
-     * `std::is_arithmetic_v<V>`.
-     */
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator== (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() == value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator== (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p == value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator!= (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() != value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator!= (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p != value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator<= (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() <= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator<= (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p >= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator< (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() < value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator< (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p > value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator>= (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() >= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator>= (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p <= value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator> (Point<Q, Cat, IV> const p, T const value) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p.quantity() > value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-    template <typename Q, typename Cat, typename IV, typename T>
-    constexpr
-    std::enable_if_t
-      <std::is_convertible_v<T, typename Point<Q, Cat, IV>::value_t>, bool>
-    operator> (T const value, Point<Q, Cat, IV> const p) noexcept
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      { return p < value; }
-#else // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS
-      = delete; // comparison with unqualified value not allowed
-#endif
-
-
-    /// @}
-    // -- END Comparison operations --------------------------------------------
 
 
     // -- BEGIN Arithmetic operations ------------------------------------------

--- a/lardataalg/Utilities/quantities.h
+++ b/lardataalg/Utilities/quantities.h
@@ -51,29 +51,6 @@
 
 
 /**
- * @def LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
- * @brief Enable implicit conversions of `Quantity` into `value_t`.
- *
- * This is likely going to break a number of features, and enabling it should
- * be followed by intense scrutiny of the tests.
- * If disabled, only the explicit conversion is supported.
- */
-#undef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
-
-/**
- * @def LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
- * @brief Enable comparisons of `Quantity` with `value_t`.
- *
- * This is likely going to break some code, and it is dangerous in that a
- * statement like `t > 5` does not really make sure `5` is the right unit.
- * With this feature disabled (which is recommended), the same comparison would
- * be written `t > 5_ms`, thus ensuring the unit is known (this comes with the
- * hassle of `using namespace util::quantities::time_literals` or such).
- */
-#undef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-
-/**
  * @brief Types of variables with a unit.
  *
  * This library uses the following concepts, vaguely inspired by Boost Units
@@ -632,10 +609,7 @@ namespace util::quantities {
       constexpr value_t value() const { return fValue; }
 
       /// Explicit conversion to the base quantity.
-#ifndef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
-      explicit
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
-      constexpr operator value_t() const
+      explicit constexpr operator value_t() const
         { return value(); }
 
       // -- BEGIN Asymmetric arithmetic operations -----------------------------
@@ -936,169 +910,6 @@ namespace util::quantities {
     // -- END Arithmetic operations --------------------------------------------
 
 
-    // -- BEGIN Comparisons ----------------------------------------------------
-    /**
-     * @name Comparisons between a Quantity and its base value type.
-     *
-     * These operations, as well as the ones implemented as member functions,
-     * are provided for convenience.
-     *
-     * Here the symmetric operations are defined, where different operands can
-     * be swapped.
-     *
-     */
-    /// @{
-
-    /*
-     * To refrain the wild matching of every type with `V`, and still retain
-     * the ability to compare to e.g. an integer rather than a double, instead
-     * of forcing `V` and `T` to match, we ask `V` to be _implicitly_
-     * convertible into `T`.
-     * In particular, any requirement must exclude `Quantity` types from
-     * matching to `V`, or the interplay with the `Quantity` vs. `Quantity`
-     * comparisons will be messy at best. Currently `Quantity` converts to
-     * its `value_t` only via explicit conversion. If this is going to change,
-     * the `V` to `T` matching requirement must become stricter, e.g.
-     * `std::is_arithmetic_v<V>`.
-     */
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator== (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() == value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator== (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q == value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator!= (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() != value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator!= (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q != value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator<= (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() <= value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator<= (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q >= value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator< (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() < value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator< (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q > value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator>= (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() >= value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator>= (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q <= value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator> (Quantity<U, T> const q, V const value) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q.value() > value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-    template <typename U, typename T, typename V>
-    constexpr
-    std::enable_if_t
-      <Quantity<U, T>::template is_compatible_value_v<V>, bool>
-    operator> (V const value, Quantity<U, T> const q) noexcept
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-      { return q < value; }
-#else
-      = delete; // forbidden
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-
-    /// @}
-    // -- END Comparisons ------------------------------------------------------
-
-
-    // -------------------------------------------------------------------------
     /**
      * @brief Alias for a quantity based on a scaled unit.
      * @tparam Unit type of unit (unscaled)

--- a/lardataalg/Utilities/quantities.h
+++ b/lardataalg/Utilities/quantities.h
@@ -910,6 +910,7 @@ namespace util::quantities {
     // -- END Arithmetic operations --------------------------------------------
 
 
+    // -------------------------------------------------------------------------
     /**
      * @brief Alias for a quantity based on a scaled unit.
      * @tparam Unit type of unit (unscaled)

--- a/test/DetectorInfo/DetectorTimingTypes_test.cc
+++ b/test/DetectorInfo/DetectorTimingTypes_test.cc
@@ -15,6 +15,7 @@
 #include "lardataalg/Utilities/quantities/spacetime.h"
 #include "larcorealg/CoreUtils/DebugUtils.h" // lar::debug::::static_assert_on<>
 #include "larcorealg/CoreUtils/MetaUtils.h" // util::is_same_decay_v
+#include "test/Utilities/disable_boost_fpc_tolerance.hpp"
 
 // C/C++ standard libraries
 #include <type_traits> // std::decay_t<>, std::is_same_v<>
@@ -108,144 +109,134 @@ static_assert(std::is_same_v<
 
 
 // -----------------------------------------------------------------------------
-template <typename Category>
-void test_time_operations() {
-  
+void test_time_operations()
+{
   using namespace util::quantities::time_literals;
-  
-  using traits_t = detinfo::timescales::timescale_traits<Category>;
-  
+  using namespace detinfo::timescales;
+
+  using traits_t = timescale_traits<OpticalTimeCategory>;
+
   BOOST_TEST_MESSAGE("Testing category: " << traits_t::name());
-  
-  using time_point_t      = typename traits_t::time_point_t;
-  using time_interval_t   = typename traits_t::time_interval_t;
-  
+
+  using time_point_t    = traits_t::time_point_t;
+  using time_interval_t = traits_t::time_interval_t;
+
   //
   // time points and intervals
   //
   time_point_t p  { 10.0_us };
   time_point_t p2 {  5.0_us };
-  
+
   time_interval_t dt { 500_ns };
-  
+
   static_assert(util::is_same_decay_v<decltype(p + dt), time_point_t>);
-  BOOST_TEST((p + dt == 10.5_us));
+  BOOST_TEST(p + dt == 10.5_us);
   static_assert(util::is_same_decay_v<decltype(p + 500_ns), time_point_t>);
-  BOOST_TEST((p + 500_ns == 10.5_us));
-  
+  BOOST_TEST(p + 500_ns == 10.5_us);
+
   static_assert(util::is_same_decay_v<decltype(p - dt), time_point_t>);
-  BOOST_TEST((p - dt == 9.5_us));
+  BOOST_TEST(p - dt == 9.5_us);
   static_assert(util::is_same_decay_v<decltype(p - 500_ns), time_point_t>);
-  BOOST_TEST((p - 500_ns ==  9.5_us));
-  
+  BOOST_TEST(p - 500_ns ==  9.5_us);
+
   static_assert(util::is_same_decay_v<decltype(p - p2), time_interval_t>);
-  BOOST_TEST((p - p2 == 5.0_us));
-  
-  
+  BOOST_TEST(p - p2 == 5.0_us);
 } // test_time_operations()
 
 
 // -----------------------------------------------------------------------------
-template <typename Category>
-void test_integral_tick_operations() {
-  
+void test_integral_tick_operations()
+{
   using namespace util::quantities::electronics_literals;
-  
-  using traits_t = detinfo::timescales::timescale_traits<Category>;
-  
+  using namespace detinfo::timescales;
+
+  using traits_t = timescale_traits<OpticalTimeCategory>;
+
   BOOST_TEST_MESSAGE("Testing category: " << traits_t::name());
-  
-  using tick_t            = typename traits_t::tick_t;
-  using tick_interval_t   = typename traits_t::tick_interval_t;
-  
+
+  using tick_t            = traits_t::tick_t;
+  using tick_interval_t   = traits_t::tick_interval_t;
+
   //
   // ticks
   //
   tick_t tick  { 100.0_tick };
   tick_t tick2 {  50.0_tick };
-  
+
   tick_interval_t dtick { 30_tick };
-  
+
   static_assert(util::is_same_decay_v<decltype(tick + dtick), tick_t>);
-  BOOST_TEST((tick + dtick == 130.0_tick));
+  BOOST_TEST(tick + dtick == 130.0_tick);
   static_assert(util::is_same_decay_v<decltype(tick + 30.0_tick), tick_t>);
-  BOOST_TEST((tick + 30.0_tick == 130.0_tick));
-  
+  BOOST_TEST(tick + 30.0_tick == 130.0_tick);
+
   static_assert(util::is_same_decay_v<decltype(tick - dtick), tick_t>);
-  BOOST_TEST((tick - dtick == 70.0_tick));
+  BOOST_TEST(tick - dtick == 70.0_tick);
   static_assert(util::is_same_decay_v<decltype(tick - 30.0_tick), tick_t>);
-  BOOST_TEST((tick - 30.0_tick == 70.0_tick));
-  
+  BOOST_TEST(tick - 30.0_tick == 70.0_tick);
+
   static_assert(util::is_same_decay_v<decltype(tick - tick2), tick_interval_t>);
-  BOOST_TEST((tick - tick2 == 50_tick));
-  
-  
+  BOOST_TEST(tick - tick2 == 50_tick);
 } // test_integral_tick_operations()
 
 
 // -----------------------------------------------------------------------------
-template <typename Category>
-void test_real_tick_operations() {
-  
+void test_real_tick_operations()
+{
   using namespace util::quantities::electronics_literals;
-  
-  using traits_t = detinfo::timescales::timescale_traits<Category>;
-  
+  using namespace detinfo::timescales;
+  using traits_t = timescale_traits<OpticalTimeCategory>;
+
   BOOST_TEST_MESSAGE("Testing category: " << traits_t::name());
-  
-  using tick_d_t          = typename traits_t::tick_d_t;
-  using tick_interval_d_t = typename traits_t::tick_interval_d_t;
-  
+
+  using tick_d_t          = traits_t::tick_d_t;
+  using tick_interval_d_t = traits_t::tick_interval_d_t;
+
   //
   // ticks
   //
   tick_d_t tick  { 100.5_tickd };
   tick_d_t tick2 {  50.0_tickd };
-  
+
   tick_interval_d_t dtick { 30_tickd };
-  
+
   static_assert(util::is_same_decay_v<decltype(tick + dtick), tick_d_t>);
-  BOOST_TEST((tick + dtick == 130.5_tickd));
+  BOOST_TEST(tick + dtick == 130.5_tickd);
   static_assert(util::is_same_decay_v<decltype(tick + 30.0_tickd), tick_d_t>);
-  BOOST_TEST((tick + 30.0_tickd == 130.5_tickd));
-  
+  BOOST_TEST(tick + 30.0_tickd == 130.5_tickd);
+
   static_assert(util::is_same_decay_v<decltype(tick - dtick), tick_d_t>);
-  BOOST_TEST((tick - dtick == 70.5_tickd));
+  BOOST_TEST(tick - dtick == 70.5_tickd);
   static_assert(util::is_same_decay_v<decltype(tick - 30.0_tickd), tick_d_t>);
-  BOOST_TEST((tick - 30.0_tickd == 70.5_tickd));
-  
+  BOOST_TEST(tick - 30.0_tickd == 70.5_tickd);
+
   static_assert
     (util::is_same_decay_v<decltype(tick - tick2), tick_interval_d_t>);
-  BOOST_TEST((tick - tick2 == 50.5_tickd));
-  
-  
+  BOOST_TEST(tick - tick2 == 50.5_tickd);
+
+
   /// Type of a point in time, measured in ticks.
-  using ClockTick_t = detinfo::timescales::optical_tick;
-  
+  using ClockTick_t = optical_tick;
+
   /// Type of a time interval, measured in ticks.
-  using ClockTicks_t = detinfo::timescales::optical_time_ticks;
-  
+  using ClockTicks_t = optical_time_ticks;
+
   ClockTick_t mytick { 10_tick };
   ClockTicks_t mydelay { 5_tick };
-  
+
   ClockTick_t delayedTick = mytick + mydelay;
-  BOOST_TEST((delayedTick == 15_tick));
-  
-  
+  BOOST_TEST(delayedTick == 15_tick);
 } // test_real_tick_operations()
 
+// ---------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
-// BEGIN Test cases  -----------------------------------------------------------
-// -----------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(OpticalTime_testcase) {
-  
-  test_time_operations<detinfo::timescales::OpticalTimeCategory>();
-  test_integral_tick_operations<detinfo::timescales::OpticalTimeCategory>();
-  test_real_tick_operations<detinfo::timescales::OpticalTimeCategory>();
-  
-} // BOOST_AUTO_TEST_CASE(OpticalTime_testcase)
+BOOST_AUTO_TEST_SUITE(DetectorTimingTypes_test)
 
-// -----------------------------------------------------------------------------
-// END Test cases  -------------------------------------------------------------
-// -----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OpticalTime_testcase)
+{
+  test_time_operations();
+  test_integral_tick_operations();
+  test_real_tick_operations();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/DetectorInfo/ProviderPack_test.cc
+++ b/test/DetectorInfo/ProviderPack_test.cc
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(test_ProviderPack) {
   auto myA = SP1.get<svc::ProviderA>();
   static_assert(std::is_same<decltype(myA), svc::ProviderA const*>(),
     "Failed to get the element of type A");
-  BOOST_CHECK_EQUAL(myA, &providerA);
+  BOOST_TEST(myA == &providerA);
 
   // get element B
   static_assert
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_ProviderPack) {
   auto myB = SP1.get<svc::ProviderB>();
   static_assert(std::is_same<decltype(myB), svc::ProviderB const*>(),
     "Failed to get the element of type B");
-  BOOST_CHECK_EQUAL(myB, &providerB);
+  BOOST_TEST(myB == &providerB);
 
   // get element C
   static_assert
@@ -125,14 +125,14 @@ BOOST_AUTO_TEST_CASE(test_ProviderPack) {
   auto myC = SP1.get<svc::ProviderC>();
   static_assert(std::is_same<decltype(myC), svc::ProviderC const*>(),
     "Failed to get the element of type C");
-  BOOST_CHECK_EQUAL(myC, &providerC);
+  BOOST_TEST(myC == &providerC);
 
 
   // set element A
   svc::ProviderA providerA2;
   SP1.set(&providerA2);
   myA = SP1.get<svc::ProviderA>();
-  BOOST_CHECK_EQUAL(myA, &providerA2);
+  BOOST_TEST(myA == &providerA2);
 
   // get element D
   // should be a compilation error
@@ -148,13 +148,13 @@ BOOST_AUTO_TEST_CASE(test_ProviderPack) {
 
   // default constructor: all null
   lar::ProviderPack<svc::ProviderA, svc::ProviderB> SP2;
-  BOOST_CHECK(SP2.get<svc::ProviderA>() == nullptr);
-  BOOST_CHECK(SP2.get<svc::ProviderB>() == nullptr);
+  BOOST_TEST(SP2.get<svc::ProviderA>() == nullptr);
+  BOOST_TEST(SP2.get<svc::ProviderB>() == nullptr);
 
   // extraction constructor
   lar::ProviderPack<svc::ProviderA, svc::ProviderB> SP3(SP1);
-  BOOST_CHECK_EQUAL(SP3.get<svc::ProviderA>(), SP1.get<svc::ProviderA>());
-  BOOST_CHECK_EQUAL(SP3.get<svc::ProviderB>(), SP1.get<svc::ProviderB>());
+  BOOST_TEST(SP3.get<svc::ProviderA>() == SP1.get<svc::ProviderA>());
+  BOOST_TEST(SP3.get<svc::ProviderB>() == SP1.get<svc::ProviderB>());
 
   // multiple elements of the same type
   // should be a compilation error

--- a/test/Utilities/MappedContainer_test.cc
+++ b/test/Utilities/MappedContainer_test.cc
@@ -114,11 +114,11 @@ void copyTest() {
   util::MappedContainer const mappedData1
     (data, mapping1, expectedMappedData1.size(), defaultValue);
 
-  BOOST_CHECK_EQUAL(mappedData1.size(), expectedMappedData1.size());
-  BOOST_CHECK_EQUAL(mappedData1.minimal_size(), expectedMappedData1.size());
+  BOOST_TEST(mappedData1.size() == expectedMappedData1.size());
+  BOOST_TEST(mappedData1.minimal_size() == expectedMappedData1.size());
 
-  BOOST_CHECK_EQUAL(mappedData1.front(), expectedMappedData1.front());
-  BOOST_CHECK_EQUAL(mappedData1.back(), expectedMappedData1.back());
+  BOOST_TEST(mappedData1.front() == expectedMappedData1.front());
+  BOOST_TEST(mappedData1.back() == expectedMappedData1.back());
 
   std::size_t i = 0;
   auto const beginIterator = mappedData1.begin();
@@ -132,50 +132,50 @@ void copyTest() {
       ? mappedData1.defaultValue()
       : data[mapping1[i]]
       ;
-    BOOST_CHECK_EQUAL(expectedRef, expectedValue); // test the test
+    BOOST_TEST(expectedRef == expectedValue); // test the test
 
-    BOOST_CHECK_EQUAL(mappedValue, expectedMappedData1[i]);
-    BOOST_CHECK_EQUAL(mappedData1[i], expectedMappedData1[i]);
-    BOOST_CHECK_EQUAL(mappedData1.at(i), expectedMappedData1[i]);
-    BOOST_CHECK_EQUAL(beginIterator[i], expectedMappedData1[i]);
-    BOOST_CHECK_EQUAL(*(beginIterator + i), expectedMappedData1[i]);
-    BOOST_CHECK_EQUAL(*mappedIterator, expectedMappedData1[i]);
+    BOOST_TEST(mappedValue == expectedMappedData1[i]);
+    BOOST_TEST(mappedData1[i] == expectedMappedData1[i]);
+    BOOST_TEST(mappedData1.at(i) == expectedMappedData1[i]);
+    BOOST_TEST(beginIterator[i] == expectedMappedData1[i]);
+    BOOST_TEST(*(beginIterator + i) == expectedMappedData1[i]);
+    BOOST_TEST(*mappedIterator == expectedMappedData1[i]);
     if (i >= 1) {
-      BOOST_CHECK_EQUAL(secondIterator[i-1], expectedMappedData1[i]);
-      BOOST_CHECK_EQUAL(*(secondIterator + i - 1), expectedMappedData1[i]);
-      BOOST_CHECK( (mappedIterator != beginIterator));
-      BOOST_CHECK(!(mappedIterator == beginIterator));
-      BOOST_CHECK( (mappedIterator >  beginIterator));
-      BOOST_CHECK( (mappedIterator >= beginIterator));
-      BOOST_CHECK(!(mappedIterator <  beginIterator));
-      BOOST_CHECK(!(mappedIterator <= beginIterator));
-      BOOST_CHECK( (beginIterator != mappedIterator));
-      BOOST_CHECK(!(beginIterator == mappedIterator));
-      BOOST_CHECK(!(beginIterator >  mappedIterator));
-      BOOST_CHECK(!(beginIterator >= mappedIterator));
-      BOOST_CHECK( (beginIterator <  mappedIterator));
-      BOOST_CHECK( (beginIterator <= mappedIterator));
+      BOOST_TEST(secondIterator[i-1] == expectedMappedData1[i]);
+      BOOST_TEST(*(secondIterator + i - 1) == expectedMappedData1[i]);
+      BOOST_TEST( (mappedIterator != beginIterator));
+      BOOST_TEST(!(mappedIterator == beginIterator));
+      BOOST_TEST( (mappedIterator >  beginIterator));
+      BOOST_TEST( (mappedIterator >= beginIterator));
+      BOOST_TEST(!(mappedIterator <  beginIterator));
+      BOOST_TEST(!(mappedIterator <= beginIterator));
+      BOOST_TEST( (beginIterator != mappedIterator));
+      BOOST_TEST(!(beginIterator == mappedIterator));
+      BOOST_TEST(!(beginIterator >  mappedIterator));
+      BOOST_TEST(!(beginIterator >= mappedIterator));
+      BOOST_TEST( (beginIterator <  mappedIterator));
+      BOOST_TEST( (beginIterator <= mappedIterator));
     }
     else {
-      BOOST_CHECK(!(mappedIterator != beginIterator));
-      BOOST_CHECK( (mappedIterator == beginIterator));
-      BOOST_CHECK(!(mappedIterator >  beginIterator));
-      BOOST_CHECK( (mappedIterator >= beginIterator));
-      BOOST_CHECK(!(mappedIterator <  beginIterator));
-      BOOST_CHECK( (mappedIterator <= beginIterator));
-      BOOST_CHECK(!(beginIterator != mappedIterator));
-      BOOST_CHECK( (beginIterator == mappedIterator));
-      BOOST_CHECK(!(beginIterator >  mappedIterator));
-      BOOST_CHECK( (beginIterator >= mappedIterator));
-      BOOST_CHECK(!(beginIterator <  mappedIterator));
-      BOOST_CHECK( (beginIterator <= mappedIterator));
+      BOOST_TEST(!(mappedIterator != beginIterator));
+      BOOST_TEST( (mappedIterator == beginIterator));
+      BOOST_TEST(!(mappedIterator >  beginIterator));
+      BOOST_TEST( (mappedIterator >= beginIterator));
+      BOOST_TEST(!(mappedIterator <  beginIterator));
+      BOOST_TEST( (mappedIterator <= beginIterator));
+      BOOST_TEST(!(beginIterator != mappedIterator));
+      BOOST_TEST( (beginIterator == mappedIterator));
+      BOOST_TEST(!(beginIterator >  mappedIterator));
+      BOOST_TEST( (beginIterator >= mappedIterator));
+      BOOST_TEST(!(beginIterator <  mappedIterator));
+      BOOST_TEST( (beginIterator <= mappedIterator));
     }
 
-    BOOST_CHECK_NE(&(mappedData1[i]), &(expectedMappedData1[i]));
+    BOOST_TEST(&mappedData1[i] != &expectedMappedData1[i]);
     ++i;
     ++mappedIterator;
   } // for
-  BOOST_CHECK_EQUAL(i, expectedMappedData1.size());
+  BOOST_TEST(i == expectedMappedData1.size());
 
   // let's check a bit of overflow
   while (i < expectedMappedData1.size() + 3U) {
@@ -229,11 +229,11 @@ void referenceTest() {
       >
     );
 
-  BOOST_CHECK_EQUAL(mappedData1.size(), expectedMappedData1.size());
-  BOOST_CHECK_EQUAL(mappedData1.minimal_size(), expectedMappedData1.size());
+  BOOST_TEST(mappedData1.size() == expectedMappedData1.size());
+  BOOST_TEST(mappedData1.minimal_size() == expectedMappedData1.size());
 
-  BOOST_CHECK_EQUAL(mappedData1.front(), expectedMappedData1.front());
-  BOOST_CHECK_EQUAL(mappedData1.back(), expectedMappedData1.back());
+  BOOST_TEST(mappedData1.front() == expectedMappedData1.front());
+  BOOST_TEST(mappedData1.back() == expectedMappedData1.back());
 
   std::size_t i = 0;
   auto const beginIterator = mappedData1.begin();
@@ -248,64 +248,64 @@ void referenceTest() {
       ? mappedData1.defaultValue()
       : data[expectedMappedIndex]
       ;
-    BOOST_CHECK_EQUAL(expectedRef, expectedValue); // test the test
+    BOOST_TEST(expectedRef == expectedValue); // test the test
 
     decltype(auto) mappedDataRef = mappedData1[i];
     static_assert(std::is_reference_v<decltype(mappedDataRef)>);
 
-    BOOST_CHECK_EQUAL(mappedData1.map_index(i), expectedMappedIndex);
-    BOOST_CHECK_EQUAL(mappedValue, expectedValue);
-    BOOST_CHECK_EQUAL(mappedDataRef, expectedValue);
-    BOOST_CHECK_EQUAL(mappedData1.at(i), expectedValue);
-    BOOST_CHECK_EQUAL(beginIterator[i], expectedValue);
-    BOOST_CHECK_EQUAL(*(beginIterator + i), expectedValue);
-    BOOST_CHECK_EQUAL(*mappedIterator, expectedValue);
+    BOOST_TEST(mappedData1.map_index(i) == expectedMappedIndex);
+    BOOST_TEST(mappedValue == expectedValue);
+    BOOST_TEST(mappedDataRef == expectedValue);
+    BOOST_TEST(mappedData1.at(i) == expectedValue);
+    BOOST_TEST(beginIterator[i] == expectedValue);
+    BOOST_TEST(*(beginIterator + i) == expectedValue);
+    BOOST_TEST(*mappedIterator == expectedValue);
     if (i >= 1) {
-      BOOST_CHECK_EQUAL(secondIterator[i-1], expectedValue);
-      BOOST_CHECK_EQUAL(*(secondIterator + i - 1), expectedValue);
-      BOOST_CHECK( (mappedIterator != beginIterator));
-      BOOST_CHECK(!(mappedIterator == beginIterator));
-      BOOST_CHECK( (mappedIterator >  beginIterator));
-      BOOST_CHECK( (mappedIterator >= beginIterator));
-      BOOST_CHECK(!(mappedIterator <  beginIterator));
-      BOOST_CHECK(!(mappedIterator <= beginIterator));
-      BOOST_CHECK( (beginIterator != mappedIterator));
-      BOOST_CHECK(!(beginIterator == mappedIterator));
-      BOOST_CHECK(!(beginIterator >  mappedIterator));
-      BOOST_CHECK(!(beginIterator >= mappedIterator));
-      BOOST_CHECK( (beginIterator <  mappedIterator));
-      BOOST_CHECK( (beginIterator <= mappedIterator));
+      BOOST_TEST(secondIterator[i-1] == expectedValue);
+      BOOST_TEST(*(secondIterator + i - 1) == expectedValue);
+      BOOST_TEST( (mappedIterator != beginIterator));
+      BOOST_TEST(!(mappedIterator == beginIterator));
+      BOOST_TEST( (mappedIterator >  beginIterator));
+      BOOST_TEST( (mappedIterator >= beginIterator));
+      BOOST_TEST(!(mappedIterator <  beginIterator));
+      BOOST_TEST(!(mappedIterator <= beginIterator));
+      BOOST_TEST( (beginIterator != mappedIterator));
+      BOOST_TEST(!(beginIterator == mappedIterator));
+      BOOST_TEST(!(beginIterator >  mappedIterator));
+      BOOST_TEST(!(beginIterator >= mappedIterator));
+      BOOST_TEST( (beginIterator <  mappedIterator));
+      BOOST_TEST( (beginIterator <= mappedIterator));
     }
     else {
-      BOOST_CHECK(!(mappedIterator != beginIterator));
-      BOOST_CHECK( (mappedIterator == beginIterator));
-      BOOST_CHECK(!(mappedIterator >  beginIterator));
-      BOOST_CHECK( (mappedIterator >= beginIterator));
-      BOOST_CHECK(!(mappedIterator <  beginIterator));
-      BOOST_CHECK( (mappedIterator <= beginIterator));
-      BOOST_CHECK(!(beginIterator != mappedIterator));
-      BOOST_CHECK( (beginIterator == mappedIterator));
-      BOOST_CHECK(!(beginIterator >  mappedIterator));
-      BOOST_CHECK( (beginIterator >= mappedIterator));
-      BOOST_CHECK(!(beginIterator <  mappedIterator));
-      BOOST_CHECK( (beginIterator <= mappedIterator));
+      BOOST_TEST(!(mappedIterator != beginIterator));
+      BOOST_TEST( (mappedIterator == beginIterator));
+      BOOST_TEST(!(mappedIterator >  beginIterator));
+      BOOST_TEST( (mappedIterator >= beginIterator));
+      BOOST_TEST(!(mappedIterator <  beginIterator));
+      BOOST_TEST( (mappedIterator <= beginIterator));
+      BOOST_TEST(!(beginIterator != mappedIterator));
+      BOOST_TEST( (beginIterator == mappedIterator));
+      BOOST_TEST(!(beginIterator >  mappedIterator));
+      BOOST_TEST( (beginIterator >= mappedIterator));
+      BOOST_TEST(!(beginIterator <  mappedIterator));
+      BOOST_TEST( (beginIterator <= mappedIterator));
     }
 
     // since `data` is captured via reference, the returned elements should be
     // exactly the same object (same physical memory location) as in the
     // original collection:
-    BOOST_CHECK_EQUAL(&mappedDataRef, &expectedRef);
+    BOOST_TEST(&mappedDataRef == &expectedRef);
 
     // mapping by reference should be equivalent to mapping by value;
     // because of out test choice, the default values are different though
     if (mapping1[i] != InvalidIndex)
-      BOOST_CHECK_EQUAL(mappedData2[i], mappedData1[i]);
-    BOOST_CHECK_EQUAL(&mappedData2.map_index(i), &expectedMappedIndex);
+      BOOST_TEST(mappedData2[i] == mappedData1[i]);
+    BOOST_TEST(&mappedData2.map_index(i) == &expectedMappedIndex);
 
     ++i;
     ++mappedIterator;
   } // for
-  BOOST_CHECK_EQUAL(i, expectedMappedData1.size());
+  BOOST_TEST(i == expectedMappedData1.size());
 
   // let's check a bit of overflow
   while (i < expectedMappedData1.size() + 3U) {
@@ -350,8 +350,8 @@ void autosizeTest() {
 
   util::MappedContainer const mappedData(std::ref(data), mapping);
 
-  BOOST_CHECK_EQUAL(mappedData.size(), mapping.size());
-  BOOST_CHECK_EQUAL(mappedData.defaultValue(), double{});
+  BOOST_TEST(mappedData.size() == mapping.size());
+  BOOST_TEST(mappedData.defaultValue() == double{});
 
 } // autosizeTest()
 

--- a/test/Utilities/MultipleChoiceSelection_test.cc
+++ b/test/Utilities/MultipleChoiceSelection_test.cc
@@ -21,28 +21,28 @@
 
 // -----------------------------------------------------------------------------
 void MultipleChoiceSelection_test() {
-  
+
   enum class Color { white, gray, black, blue };
-  
+
   using OptionSelector_t = util::MultipleChoiceSelection<Color>;
-  
+
   OptionSelector_t options {
     { Color::black, "black" },
     { Color::gray, "gray", "grey" }
     };
-  
+
   BOOST_TEST(options.size() == 2U);
-  
+
   BOOST_CHECK_THROW(
     options.addAlias(Color::white, "blanche"), // Color::white not yet added
     OptionSelector_t::UnknownOptionError
     );
-  
+
   auto const& opWhite0 = options.addOption(Color::white, "white");
   auto const& opWhite0again = options.addAlias(Color::white, "blanche");
   BOOST_TEST(&opWhite0again == &opWhite0);
   BOOST_TEST(options.size() == 3U);
-  
+
   std::cout << "Options:\n" << options.optionListDump(" * ") << std::endl;
 
   BOOST_TEST( options.hasOption(Color::white));
@@ -52,12 +52,12 @@ void MultipleChoiceSelection_test() {
   BOOST_TEST( options.hasOption("blanche"));
   BOOST_TEST( options.hasOption("wHite"));
   BOOST_TEST(!options.hasOption("blue"));
-  
+
   //
   // white
   //
-  BOOST_CHECK(options.hasOption(opWhite0));
-  
+  BOOST_TEST(options.hasOption(opWhite0));
+
   auto const opWhite1 = options.parse("white");
   static_assert(std::is_same_v
     <std::decay_t<decltype(opWhite1)>, OptionSelector_t::Option_t>
@@ -65,7 +65,7 @@ void MultipleChoiceSelection_test() {
   BOOST_TEST((opWhite1 == Color::white));
   BOOST_TEST(opWhite1 == "white");
   BOOST_TEST(opWhite1 == opWhite0);
-  
+
   auto const opWhite2 = options.parse("blanche");
   static_assert(std::is_same_v
     <std::decay_t<decltype(opWhite2)>, OptionSelector_t::Option_t>
@@ -75,13 +75,13 @@ void MultipleChoiceSelection_test() {
   BOOST_TEST(opWhite2 == "blanche");
   BOOST_TEST(opWhite2 == "Blanche");
   BOOST_TEST(opWhite2 == opWhite0);
-  
+
   auto const opWhite3 = options.get("white");
   static_assert(std::is_same_v
     <std::decay_t<decltype(opWhite1)>, OptionSelector_t::Option_t>
     );
   BOOST_TEST(opWhite3 == "white");
-  
+
   //
   // gray
   //
@@ -90,7 +90,7 @@ void MultipleChoiceSelection_test() {
     <std::decay_t<decltype(opWhite1)>, OptionSelector_t::Option_t>
     );
   BOOST_TEST(opWhite0 == "white");
-  
+
   auto const opGray1 = options.parse("gray");
   static_assert(std::is_same_v
     <std::decay_t<decltype(opWhite1)>, OptionSelector_t::Option_t>
@@ -99,17 +99,17 @@ void MultipleChoiceSelection_test() {
   BOOST_TEST(opGray1 == "gray");
   BOOST_TEST(opGray1 == "grey");
   BOOST_TEST(opGray1 == opGray0);
-  
+
   Color color = opGray1;
   BOOST_TEST((color == Color::gray));
-  
+
   //
   // blue
   //
   BOOST_CHECK_THROW(options.get("blue"), OptionSelector_t::UnknownOptionError);
   BOOST_CHECK_THROW
     (options.parse("blue"), OptionSelector_t::UnknownOptionError);
-  
+
 } // MultipleChoiceSelection_testcase()
 
 

--- a/test/Utilities/StatCollector_test.cc
+++ b/test/Utilities/StatCollector_test.cc
@@ -33,11 +33,12 @@
  */
 #define BOOST_TEST_MODULE ( StatCollector_test )
 #include <boost/test/unit_test.hpp>
-#include <boost/test/tools/floating_point_comparison.hpp> // BOOST_CHECK_CLOSE()
 
 // LArSoft libraries
 #include "lardataalg/Utilities/StatCollector.h"
 
+
+using boost::test_tools::tolerance;
 
 //------------------------------------------------------------------------------
 //--- Test code
@@ -55,18 +56,18 @@ void CheckStats(
 
   using Weight_t = W;
 
-  BOOST_CHECK_EQUAL(stats.N(),       n);
+  BOOST_TEST(stats.N() == n);
   if (n == 0) {
     BOOST_CHECK_THROW(stats.AverageWeight(), std::range_error);
   }
   else {
     const Weight_t average = weights / n;
-    BOOST_CHECK_CLOSE(double(stats.AverageWeight()), double(average), 0.1);
+    BOOST_TEST(double(stats.AverageWeight()) == double(average), 0.1% tolerance());
   }
   if (weights == 0.) {
-    BOOST_CHECK_SMALL(double(stats.Weights()), 0.01);
-    BOOST_CHECK_SMALL(double(stats.Sum()),     0.01);
-    BOOST_CHECK_SMALL(double(stats.SumSq()),   0.01);
+    BOOST_TEST(double(stats.Weights()) == 0, 0.01% tolerance());
+    BOOST_TEST(double(stats.Sum()) == 0,     0.01% tolerance());
+    BOOST_TEST(double(stats.SumSq()) == 0,   0.01% tolerance());
     BOOST_CHECK_THROW(stats.Average(),  std::range_error);
     BOOST_CHECK_THROW(stats.Variance(), std::range_error);
     BOOST_CHECK_THROW(stats.RMS(),      std::range_error);
@@ -74,12 +75,12 @@ void CheckStats(
   else {
     const Weight_t average = sum / weights;
     // check at precision 0.01% or 0.1%
-    BOOST_CHECK_CLOSE(double(stats.Weights()),  double(weights), 0.01);
-    BOOST_CHECK_CLOSE(double(stats.Sum()),      double(sum),     0.01);
-    BOOST_CHECK_CLOSE(double(stats.SumSq()),    double(sumsq),   0.01);
-    BOOST_CHECK_CLOSE(double(stats.Average()),  double(average), 0.1);
-    BOOST_CHECK_CLOSE(double(stats.Variance()), double(rms*rms), 0.1);
-    BOOST_CHECK_CLOSE(double(stats.RMS()),      double(rms),     0.1);
+    BOOST_TEST(double(stats.Weights()) ==  double(weights), 0.01% tolerance());
+    BOOST_TEST(double(stats.Sum()) ==      double(sum),     0.01% tolerance());
+    BOOST_TEST(double(stats.SumSq()) ==    double(sumsq),   0.01% tolerance());
+    BOOST_TEST(double(stats.Average()) ==  double(average), 0.1% tolerance());
+    BOOST_TEST(double(stats.Variance()) == double(rms*rms), 0.1% tolerance());
+    BOOST_TEST(double(stats.RMS()) ==      double(rms),     0.1% tolerance());
   }
 } // CheckStats<>(StatCollector)
 
@@ -101,28 +102,28 @@ void CheckStats(
 
   using Weight_t = W;
 
-  BOOST_CHECK_EQUAL(stats.N(),       n);
+  BOOST_TEST(stats.N() ==       n);
   if (n == 0) {
     BOOST_CHECK_THROW(stats.AverageWeight(), std::range_error);
   }
   else {
     const Weight_t average = weights / n;
-    BOOST_CHECK_CLOSE(double(stats.AverageWeight()), double(average), 0.1);
+    BOOST_TEST(double(stats.AverageWeight()) == double(average), 0.1% tolerance());
   }
 
   if (weights == 0.) {
-    BOOST_CHECK_SMALL(double(stats.Weights()),  0.01);
-    BOOST_CHECK_SMALL(double(stats.SumX()),     0.01);
-    BOOST_CHECK_SMALL(double(stats.SumSqX()),   0.01);
+    BOOST_TEST(double(stats.Weights()) == 0,  0.01% tolerance());
+    BOOST_TEST(double(stats.SumX()) == 0,     0.01% tolerance());
+    BOOST_TEST(double(stats.SumSqX()) == 0,   0.01% tolerance());
     BOOST_CHECK_THROW(stats.AverageX(),          std::range_error);
     BOOST_CHECK_THROW(stats.VarianceX(),         std::range_error);
     BOOST_CHECK_THROW(stats.RMSx(),              std::range_error);
-    BOOST_CHECK_SMALL(double(stats.SumY()),     0.01);
-    BOOST_CHECK_SMALL(double(stats.SumSqY()),   0.01);
+    BOOST_TEST(double(stats.SumY()) == 0,     0.01% tolerance());
+    BOOST_TEST(double(stats.SumSqY()) == 0,   0.01% tolerance());
     BOOST_CHECK_THROW(stats.AverageY(),          std::range_error);
     BOOST_CHECK_THROW(stats.VarianceY(),         std::range_error);
     BOOST_CHECK_THROW(stats.RMSy(),              std::range_error);
-    BOOST_CHECK_SMALL(double(stats.SumXY()),    0.01);
+    BOOST_TEST(double(stats.SumXY()) == 0,    0.01% tolerance());
     BOOST_CHECK_THROW(stats.Covariance(),        std::range_error);
     BOOST_CHECK_THROW(stats.LinearCorrelation(), std::range_error);
   }
@@ -130,20 +131,21 @@ void CheckStats(
     const Weight_t averageX = sumX / weights;
     const Weight_t averageY = sumY / weights;
     // check at precision 0.01% or 0.1%
-    BOOST_CHECK_CLOSE(double(stats.Weights()),           double(weights),   0.01);
-    BOOST_CHECK_CLOSE(double(stats.SumX()),              double(sumX),      0.01);
-    BOOST_CHECK_CLOSE(double(stats.SumSqX()),            double(sumsqX),    0.01);
-    BOOST_CHECK_CLOSE(double(stats.AverageX()),          double(averageX),  0.1);
-    BOOST_CHECK_CLOSE(double(stats.VarianceX()),         double(rmsX*rmsX), 0.1);
-    BOOST_CHECK_CLOSE(double(stats.RMSx()),              double(rmsX),      0.1);
-    BOOST_CHECK_CLOSE(double(stats.SumY()),              double(sumY),      0.01);
-    BOOST_CHECK_CLOSE(double(stats.SumSqY()),            double(sumsqY),    0.01);
-    BOOST_CHECK_CLOSE(double(stats.AverageY()),          double(averageY),  0.1);
-    BOOST_CHECK_CLOSE(double(stats.VarianceY()),         double(rmsY*rmsY), 0.1);
-    BOOST_CHECK_CLOSE(double(stats.RMSy()),              double(rmsY),      0.1);
-    BOOST_CHECK_CLOSE(double(stats.SumXY()),             double(sumXY),     0.01);
-    BOOST_CHECK_CLOSE(double(stats.Covariance()),        double(cov),       0.1);
-    BOOST_CHECK_CLOSE(double(stats.LinearCorrelation()), double(lin_corr),  0.1);
+
+    BOOST_TEST(double(stats.Weights()) ==           double(weights),   0.01% tolerance());
+    BOOST_TEST(double(stats.SumX()) ==              double(sumX),      0.01% tolerance());
+    BOOST_TEST(double(stats.SumSqX()) ==            double(sumsqX),    0.01% tolerance());
+    BOOST_TEST(double(stats.AverageX()) ==          double(averageX),  0.1% tolerance());
+    BOOST_TEST(double(stats.VarianceX()) ==         double(rmsX*rmsX), 0.1% tolerance());
+    BOOST_TEST(double(stats.RMSx()) ==              double(rmsX),      0.1% tolerance());
+    BOOST_TEST(double(stats.SumY()) ==              double(sumY),      0.01% tolerance());
+    BOOST_TEST(double(stats.SumSqY()) ==            double(sumsqY),    0.01% tolerance());
+    BOOST_TEST(double(stats.AverageY()) ==          double(averageY),  0.1% tolerance());
+    BOOST_TEST(double(stats.VarianceY()) ==         double(rmsY*rmsY), 0.1% tolerance());
+    BOOST_TEST(double(stats.RMSy()) ==              double(rmsY),      0.1% tolerance());
+    BOOST_TEST(double(stats.SumXY()) ==             double(sumXY),     0.01% tolerance());
+    BOOST_TEST(double(stats.Covariance()) ==        double(cov),       0.1% tolerance());
+    BOOST_TEST(double(stats.LinearCorrelation()) == double(lin_corr),  0.1% tolerance());
   }
 
 } // CheckStats<>(StatCollector2D)
@@ -459,22 +461,22 @@ void MinMaxCollectorTest() {
   collector.reset(new lar::util::MinMaxCollector<Data_t>);
 
   // there should be no data now
-  BOOST_CHECK(!collector->has_data());
+  BOOST_TEST(!collector->has_data());
 
   collector->add(Data_t(10));
   // there should be some data now
-  BOOST_CHECK(collector->has_data());
+  BOOST_TEST(collector->has_data());
 
-  BOOST_CHECK_EQUAL(collector->min(), Data_t(  10));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t(  10));
+  BOOST_TEST(collector->min() == Data_t(  10));
+  BOOST_TEST(collector->max() == Data_t(  10));
 
   collector->add(more_data);
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -20));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 121));
+  BOOST_TEST(collector->min() == Data_t( -20));
+  BOOST_TEST(collector->max() == Data_t( 121));
 
   collector->add(even_more_data.begin(), even_more_data.end());
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -20));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 123));
+  BOOST_TEST(collector->min() == Data_t( -20));
+  BOOST_TEST(collector->max() == Data_t( 123));
 
   //
   // 2. from initializer list constructor
@@ -482,22 +484,22 @@ void MinMaxCollectorTest() {
   collector.reset(new lar::util::MinMaxCollector<Data_t>{ -25, 3, 1 });
 
   // there should be data already
-  BOOST_CHECK(collector->has_data());
+  BOOST_TEST(collector->has_data());
 
   collector->add(Data_t(10));
   // there should still be some data
-  BOOST_CHECK(collector->has_data());
+  BOOST_TEST(collector->has_data());
 
-  BOOST_CHECK_EQUAL(collector->min(), Data_t(  -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t(  10));
+  BOOST_TEST(collector->min() == Data_t(  -25));
+  BOOST_TEST(collector->max() == Data_t(  10));
 
   collector->add(more_data);
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 121));
+  BOOST_TEST(collector->min() == Data_t( -25));
+  BOOST_TEST(collector->max() == Data_t( 121));
 
   collector->add(even_more_data.begin(), even_more_data.end());
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 123));
+  BOOST_TEST(collector->min() == Data_t( -25));
+  BOOST_TEST(collector->max() == Data_t( 123));
 
 
   //
@@ -511,22 +513,22 @@ void MinMaxCollectorTest() {
     );
 
   // there should be data already
-  BOOST_CHECK(collector->has_data());
+  BOOST_TEST(collector->has_data());
 
   collector->add(Data_t(10));
   // there should still be some data
-  BOOST_CHECK(collector->has_data());
+  BOOST_TEST(collector->has_data());
 
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t(  10));
+  BOOST_TEST(collector->min() == Data_t( -25));
+  BOOST_TEST(collector->max() == Data_t(  10));
 
   collector->add(more_data);
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 121));
+  BOOST_TEST(collector->min() == Data_t( -25));
+  BOOST_TEST(collector->max() == Data_t( 121));
 
   collector->add(even_more_data.begin(), even_more_data.end());
-  BOOST_CHECK_EQUAL(collector->min(), Data_t( -25));
-  BOOST_CHECK_EQUAL(collector->max(), Data_t( 123));
+  BOOST_TEST(collector->min() == Data_t( -25));
+  BOOST_TEST(collector->max() == Data_t( 123));
 
 } // MinMaxCollectorTest()
 

--- a/test/Utilities/disable_boost_fpc_tolerance.hpp
+++ b/test/Utilities/disable_boost_fpc_tolerance.hpp
@@ -1,0 +1,40 @@
+#ifndef LARDATAALG_TEST_UTILITIES_DISABLE_BOOST_FPC_TOLERANCE_HPP
+#define LARDATAALG_TEST_UTILITIES_DISABLE_BOOST_FPC_TOLERANCE_HPP
+
+#include <boost/test/tools/floating_point_comparison.hpp>
+
+#include "lardataalg/Utilities/quantities.h"
+#include "lardataalg/Utilities/quantities/electronics.h"
+
+// Because util::quantites::seconds (etc.) has std::numeric_limits<>
+// specializations, the Boost unit test suite assumes they are
+// suitable for floating-point comparisons, particularly tolerance
+// testing (due to the inexact nature of the representation).  The
+// following specializations disable such tolerance testing.
+
+namespace boost::math::fpc {
+  template <>
+  struct tolerance_based<util::quantities::seconds> : std::false_type {};
+  template <>
+  struct tolerance_based<util::quantities::milliseconds> : std::false_type {};
+  template <>
+  struct tolerance_based<util::quantities::microseconds> : std::false_type {};
+  template <>
+  struct tolerance_based<util::quantities::nanoseconds> : std::false_type {};
+
+  // Intervals
+  template <>
+  struct tolerance_based<util::quantities::intervals::microseconds> : std::false_type {};
+
+  // Points
+  template <>
+  struct tolerance_based<util::quantities::points::millisecond> : std::false_type {};
+  template <>
+  struct tolerance_based<util::quantities::points::microsecond> : std::false_type {};
+
+  // Electronics
+  template <>
+  struct tolerance_based<util::quantities::tick_d> : std::false_type {};
+}
+
+#endif /* LARDATAALG_TEST_UTILITIES_DISABLE_BOOST_FPC_TOLERANCE_HPP */

--- a/test/Utilities/intervals_fhicl_test.cc
+++ b/test/Utilities/intervals_fhicl_test.cc
@@ -27,7 +27,7 @@
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 template <typename Config>
-fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
+Config validateConfig(fhicl::ParameterSet const& pset) {
   fhicl::Table<Config> validatedConfig { fhicl::Name("validatedConfig") };
 
   std::cout << std::string(80, '-') << std::endl;
@@ -40,15 +40,14 @@ fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
   std::cout << std::endl;
 
   validatedConfig.validate_ParameterSet(pset);
-  return validatedConfig;
+  return validatedConfig();
 } // validateConfig()
 
 
 // -----------------------------------------------------------------------------
 template <typename Config>
-fhicl::Table<Config> validateConfig(std::string const& configStr) {
-  auto pset = fhicl::ParameterSet::make(configStr);
-  return validateConfig<Config>(pset);
+Config validateConfig(std::string const& configStr) {
+  return validateConfig<Config>(fhicl::ParameterSet::make(configStr));
 } // validateConfig(Config)
 
 
@@ -171,7 +170,7 @@ void test_read() {
   util::quantities::points::microsecond const expectedEnd { 6_ms };
   util::quantities::intervals::microseconds const expectedDuration { 16_ms };
 
-  auto validatedConfig = validateConfig<Config>(configStr)();
+  auto validatedConfig = validateConfig<Config>(configStr);
   BOOST_TEST(validatedConfig.start() == expectedStart);
   BOOST_TEST(validatedConfig.end() == expectedEnd);
   BOOST_TEST(validatedConfig.duration() == expectedDuration);
@@ -204,7 +203,7 @@ void test_write() {
   pset.put("start", expectedStart);
   pset.put("duration", expectedDuration);
 
-  auto validatedConfig = validateConfig<Config>(pset)();
+  auto validatedConfig = validateConfig<Config>(pset);
   BOOST_TEST(validatedConfig.start() == expectedStart);
   BOOST_TEST(validatedConfig.end() == expectedEnd);
   BOOST_TEST(validatedConfig.duration() == expectedDuration);

--- a/test/Utilities/intervals_fhicl_test.cc
+++ b/test/Utilities/intervals_fhicl_test.cc
@@ -14,6 +14,7 @@
 // LArSoft libraries
 #include "lardataalg/Utilities/quantities/spacetime.h"
 #include "lardataalg/Utilities/intervals_fhicl.h"
+#include "test/Utilities/disable_boost_fpc_tolerance.hpp"
 
 // support libraries
 #include "fhiclcpp/types/Table.h"
@@ -28,7 +29,7 @@
 template <typename Config>
 fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
   fhicl::Table<Config> validatedConfig { fhicl::Name("validatedConfig") };
-  
+
   std::cout << std::string(80, '-') << std::endl;
   std::cout << "===> FHiCL configuration:";
   if (pset.is_empty()) std::cout << " <empty>";
@@ -37,7 +38,7 @@ fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
   validatedConfig.print_allowed_configuration
     (std::cout << "===> Expected configuration: ");
   std::cout << std::endl;
-  
+
   validatedConfig.validate_ParameterSet(pset);
   return validatedConfig;
 } // validateConfig()
@@ -46,8 +47,7 @@ fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
 // -----------------------------------------------------------------------------
 template <typename Config>
 fhicl::Table<Config> validateConfig(std::string const& configStr) {
-  fhicl::ParameterSet pset;
-  pset = fhicl::ParameterSet::make(configStr);
+  auto pset = fhicl::ParameterSet::make(configStr);
   return validateConfig<Config>(pset);
 } // validateConfig(Config)
 
@@ -63,15 +63,15 @@ void test_makeInterval() {
 
   auto t = util::quantities::makeInterval<microseconds>("-7e1 ms"sv);
   static_assert(std::is_same_v<decltype(t), microseconds>);
-  BOOST_TEST((t == -70000_us));
-  BOOST_TEST((t == -70_ms));
+  BOOST_TEST(t == -70000_us);
+  BOOST_TEST(t == -70_ms);
 
   t = util::quantities::makeInterval<microseconds>("7e1ms"sv);
-  BOOST_TEST((t == 70000_us));
-  BOOST_TEST((t == 70_ms));
+  BOOST_TEST(t == 70000_us);
+  BOOST_TEST(t == 70_ms);
 
   t = util::quantities::makeInterval<microseconds>("7e1"sv, true);
-  BOOST_TEST((t == 70_us));
+  BOOST_TEST(t == 70_us);
 
   BOOST_CHECK_THROW(
     util::quantities::makeInterval<microseconds>("7e1"sv),
@@ -110,15 +110,15 @@ void test_makePoint() {
 
   auto t = util::quantities::makePoint<microsecond>("-7e1 ms"sv);
   static_assert(std::is_same_v<decltype(t), microsecond>);
-  BOOST_TEST((t == -70000_us));
-  BOOST_TEST((t == -70_ms));
+  BOOST_TEST(t == -70000_us);
+  BOOST_TEST(t == -70_ms);
 
   t = util::quantities::makePoint<microsecond>("7e1ms"sv);
-  BOOST_TEST((t == 70000_us));
-  BOOST_TEST((t == 70_ms));
+  BOOST_TEST(t == 70000_us);
+  BOOST_TEST(t == 70_ms);
 
   t = util::quantities::makePoint<microsecond>("7e1"sv, true);
-  BOOST_TEST((t == 70_us));
+  BOOST_TEST(t == 70_us);
 
   BOOST_CHECK_THROW(
     util::quantities::makePoint<microsecond>("7e1"sv),
@@ -150,119 +150,85 @@ void test_makePoint() {
 
 // -----------------------------------------------------------------------------
 void test_read() {
-  
+
   using namespace util::quantities::time_literals;
-  
+
   struct Config {
-    
+
     fhicl::Atom<util::quantities::points::microsecond> start
       { fhicl::Name("start"), 0_us };
-    
+
     fhicl::Atom<util::quantities::points::microsecond> end
       { fhicl::Name("end"), 6_ms };
-    
+
     fhicl::Atom<util::quantities::intervals::microseconds> duration
       { fhicl::Name("duration"), 6_ms };
-    
+
   }; // struct Config
-  
+
   std::string const configStr { "start: 2ms duration: 16ms" };
   util::quantities::points::microsecond const expectedStart { 2_ms };
   util::quantities::points::microsecond const expectedEnd { 6_ms };
   util::quantities::intervals::microseconds const expectedDuration { 16_ms };
-  
+
   auto validatedConfig = validateConfig<Config>(configStr)();
-  
-  auto start = validatedConfig.start();
-  static_assert
-    (std::is_same_v<decltype(start), util::quantities::points::microsecond>);
-  BOOST_TEST((start == expectedStart));
-  
-  auto end = validatedConfig.end();
-  static_assert
-    (std::is_same_v<decltype(end), util::quantities::points::microsecond>);
-  BOOST_TEST((end == expectedEnd));
-  
-  auto duration = validatedConfig.duration();
-  static_assert(std::is_same_v
-    <decltype(duration), util::quantities::intervals::microseconds>
-    );
-  BOOST_TEST((duration == expectedDuration));
-  
+  BOOST_TEST(validatedConfig.start() == expectedStart);
+  BOOST_TEST(validatedConfig.end() == expectedEnd);
+  BOOST_TEST(validatedConfig.duration() == expectedDuration);
+
 } // test_read()
 
 
 // -----------------------------------------------------------------------------
 void test_write() {
-  
+
   using namespace util::quantities::time_literals;
   struct Config {
-    
+
     fhicl::Atom<util::quantities::points::microsecond> start
       { fhicl::Name("start"), 0_us };
-    
+
     fhicl::Atom<util::quantities::points::microsecond> end
       { fhicl::Name("end"), 6_ms };
-    
+
     fhicl::Atom<util::quantities::intervals::microseconds> duration
       { fhicl::Name("duration"), 6_ms };
-    
+
   }; // struct Config
-  
+
   util::quantities::points::microsecond const expectedStart { 2_ms };
   util::quantities::points::microsecond const expectedEnd { 6_ms };
   util::quantities::intervals::microseconds const expectedDuration { 16_ms };
-  
+
   fhicl::ParameterSet pset;
-  pset.put<util::quantities::points::microsecond>("start", expectedStart);
-  pset.put<util::quantities::intervals::microseconds>
-    ("duration", expectedDuration);
-  
+  pset.put("start", expectedStart);
+  pset.put("duration", expectedDuration);
+
   auto validatedConfig = validateConfig<Config>(pset)();
-  
-  auto start = validatedConfig.start();
-  static_assert
-    (std::is_same_v<decltype(start), util::quantities::points::microsecond>);
-  BOOST_TEST((start == expectedStart));
-  
-  auto end = validatedConfig.end();
-  static_assert
-    (std::is_same_v<decltype(end), util::quantities::points::microsecond>);
-  BOOST_TEST((end == expectedEnd));
-  
-  auto duration = validatedConfig.duration();
-  static_assert(std::is_same_v
-    <decltype(duration), util::quantities::intervals::microseconds>
-    );
-  BOOST_TEST((duration == expectedDuration));
-  
+  BOOST_TEST(validatedConfig.start() == expectedStart);
+  BOOST_TEST(validatedConfig.end() == expectedEnd);
+  BOOST_TEST(validatedConfig.duration() == expectedDuration);
+
 } // test_write()
 
+// ----------------------------------------------------------------------------
 
-// -----------------------------------------------------------------------------
-// BEGIN Test cases  -----------------------------------------------------------
-// -----------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(intervals_testcase) {
+BOOST_AUTO_TEST_SUITE(intervals_fhicl_test)
 
+BOOST_AUTO_TEST_CASE(intervals_testcase)
+{
   test_makeInterval();
+}
 
-} // BOOST_AUTO_TEST_CASE(intervals_testcase)
-
-// -----------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(points_testcase) {
-
+BOOST_AUTO_TEST_CASE(points_testcase)
+{
   test_makePoint();
+}
 
-} // BOOST_AUTO_TEST_CASE(points_testcase)
-
-// -----------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(quantities_fhicl_testcase) {
-
+BOOST_AUTO_TEST_CASE(quantities_fhicl_testcase)
+{
   test_read();
   test_write();
+}
 
-} // BOOST_AUTO_TEST_CASE(quantities_fhicl_testcase)
-
-// -----------------------------------------------------------------------------
-// END Test cases  -------------------------------------------------------------
-// -----------------------------------------------------------------------------
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/Utilities/intervals_test.cc
+++ b/test/Utilities/intervals_test.cc
@@ -19,7 +19,16 @@
 
 
 // C/C++ standard libraries
-#include <type_traits> // std::decay_t<>
+#include <type_traits>
+
+namespace {
+  template <typename T, typename U>
+  void
+  static_assert_type(U&&)
+  {
+    static_assert(std::is_same_v<T, U>);
+  }
+}
 
 // -----------------------------------------------------------------------------
 // --- implementation detail tests
@@ -178,10 +187,10 @@ void test_interval_comparisons() {
   using util::quantities::intervals::microseconds;
   using util::quantities::intervals::nanoseconds;
 
-  constexpr microseconds const t1 {         +6.0_us };
-  constexpr nanoseconds  const t2 { -4'000'000.0_ps };
+  constexpr microseconds t1 {         +6.0_us };
+  constexpr nanoseconds  t2 { -4'000'000.0_ps };
 
-  constexpr microseconds const t1s = t1;
+  constexpr microseconds t1s = t1;
 
   static_assert(  t1      == 6_us    );
   static_assert(  t1      == 6000_ns );
@@ -288,7 +297,6 @@ void test_interval_queries() {
 
 } // test_interval_queries()
 
-
 // -----------------------------------------------------------------------------
 void test_interval_operations() {
 
@@ -300,63 +308,69 @@ void test_interval_operations() {
   constexpr microseconds ct1 {    +6.0_us };
   constexpr microseconds ct2 { -4000.0_ns };
 
-  static_assert(std::is_same_v<decltype(ct1 + -4000.0_ns), microseconds>);
+  static_assert_type<microseconds>(ct1 + -4000.0_ns);
   static_assert(ct1 + -4000.0_ns == 2_us);
 
-  static_assert(std::is_same_v<decltype(ct1 + ct2), microseconds>);
+  static_assert_type<microseconds>(ct1 + ct2);
   static_assert(ct1 + ct2 == 2_us);
 
-  static_assert(std::is_same_v<decltype(ct1 - -4000.0_ns), microseconds>);
+  static_assert_type<microseconds>(ct1 - -4000.0_ns);
   static_assert(ct1 - -4000.0_ns == 10_us);
 
-  static_assert(std::is_same_v<decltype(ct1 - ct2), microseconds>);
+  static_assert_type<microseconds>(ct1 - ct2);
   static_assert(ct1 - ct2 == 10_us);
 
-  static_assert(std::is_same_v<decltype(+ct1), microseconds>);
+  static_assert_type<microseconds>(+ct1);
   static_assert(+ct1 == 6_us);
 
-  static_assert(std::is_same_v<decltype(-ct1), microseconds>);
+  static_assert_type<microseconds>(-ct1);
   static_assert(-ct1 == -6_us);
 
-  static_assert(std::is_same_v<decltype(ct1.abs()), microseconds>);
+  static_assert_type<microseconds>(ct1.abs());
   static_assert(ct1.abs() == 6_us);
   static_assert(ct2.abs() == 4_us);
 
-  static_assert(std::is_same_v<decltype(ct1 * 3.0), microseconds>);
+  static_assert_type<microseconds>(ct1 * 3.0);
   static_assert(ct1 * 3.0 == 6_us * 3.0);
 
-  static_assert(std::is_same_v<decltype(3.0 * ct1), microseconds>);
+  static_assert_type<microseconds>(3.0 * ct1);
   static_assert(3.0 * ct1 == 6_us * 3.0);
 
-  static_assert(std::is_same_v<decltype(ct1 / 2.0), microseconds>);
+  static_assert_type<microseconds>(ct1 / 2.0);
   static_assert(ct1 / 2.0 == 6_us / 2.0);
 
-  microseconds t1 {    +6.0_us };
-  nanoseconds t2  { -4000.0_ns };
+  microseconds t1      {    +6.0_us };
+  nanoseconds const t2 { -4000.0_ns };
 
-  microseconds& incr = (t1 += 2000_ns);
+  decltype(auto) incr = (t1 += 2000_ns);
+  static_assert_type<microseconds&>(incr);
   BOOST_TEST(t1 == 8_us);
   BOOST_TEST(&incr == &t1);
 
-  microseconds& incr2 = (t1 += t2);
+  decltype(auto) incr2 = (t1 += t2);
+  static_assert_type<microseconds&>(incr2);
   BOOST_TEST(t1 ==  4_us);
   BOOST_TEST(t2 == -4_us);
   BOOST_TEST(&incr2 == &t1);
 
-  microseconds& decr = (t1 -= 2000_ns);
+  decltype(auto) decr = (t1 -= 2000_ns);
+  static_assert_type<microseconds&>(decr);
   BOOST_TEST(t1 == 2_us);
   BOOST_TEST(&decr == &t1);
 
-  microseconds& decr2 = (t1 -= t2);
+  decltype(auto) decr2 = (t1 -= t2);
+  static_assert_type<microseconds&>(decr2);
   BOOST_TEST(t1 ==  6_us);
   BOOST_TEST(t2 == -4_us);
   BOOST_TEST(&decr2 == &t1);
 
-  microseconds& expand = (t1 *= 2);
+  decltype(auto) expand = (t1 *= 2);
+  static_assert_type<microseconds&>(expand);
   BOOST_TEST(t1 == 12_us);
   BOOST_TEST(&expand == &t1);
 
-  microseconds& shrink = (t1 /= 2);
+  decltype(auto) shrink = (t1 /= 2);
+  static_assert_type<microseconds&>(shrink);
   BOOST_TEST(t1 == 6_us);
   BOOST_TEST(&shrink == &t1);
 
@@ -517,42 +531,46 @@ void test_point_operations() {
   constexpr microsecond cp1 {    +6.0_us };
   constexpr util::quantities::intervals::microseconds ct { 3.0_us };
 
-  static_assert(std::is_same_v<decltype(cp1 + 3000_ns), microsecond>);
+  static_assert_type<microsecond>(cp1 + 3000_ns);
   static_assert(cp1 + 3000_ns == 9_us);
 
-  static_assert(std::is_same_v<decltype(cp1 + ct), microsecond>);
+  static_assert_type<microsecond>(cp1 + ct);
   static_assert(cp1 + ct == 9_us);
 
-  static_assert(std::is_same_v<decltype(cp1 - 3000_ns), microsecond>);
+  static_assert_type<microsecond>(cp1 - 3000_ns);
   static_assert(cp1 - 3000_ns == 3_us);
 
-  static_assert(std::is_same_v<decltype(cp1 - ct), microsecond>);
+  static_assert_type<microsecond>(cp1 - ct);
   static_assert(cp1 - ct == 3_us);
 
-  static_assert(std::is_same_v<decltype(+cp1), microsecond>);
+  static_assert_type<microsecond>(+cp1);
   static_assert(+cp1 == 6_us);
 
-  static_assert(std::is_same_v<decltype(-cp1), microsecond>);
+  static_assert_type<microsecond>(-cp1);
   static_assert(-cp1 == -6_us);
 
   microsecond p1 {    +6.0_us };
   microsecond p2 { -4000.0_ns };
   util::quantities::intervals::nanoseconds t { 3000.0_ns };
 
-  microsecond& incr = (p1 += 2000_ns);
+  decltype(auto) incr = (p1 += 2000_ns);
+  static_assert_type<microsecond&>(incr);
   BOOST_TEST(p1 == 8_us);
   BOOST_TEST(&incr == &p1);
 
-  microsecond& incr2 = (p1 += t);
+  decltype(auto) incr2 = (p1 += t);
+  static_assert_type<microsecond&>(incr2);
   BOOST_TEST(p1 == 11_us);
   BOOST_TEST(t ==   3_us);
   BOOST_TEST(&incr2 == &p1);
 
-  microsecond& decr = (p1 -= 2000_ns);
+  decltype(auto) decr = (p1 -= 2000_ns);
+  static_assert_type<microsecond&>(decr);
   BOOST_TEST(p1 == 9_us);
   BOOST_TEST(&decr == &p1);
 
-  microsecond& decr2 = (p1 -= t);
+  decltype(auto) decr2 = (p1 -= t);
+  static_assert_type<microsecond&>(decr2);
   BOOST_TEST(p1 ==  6_us);
   BOOST_TEST(t ==   3_us);
   BOOST_TEST(&decr2 == &p1);

--- a/test/Utilities/intervals_test.cc
+++ b/test/Utilities/intervals_test.cc
@@ -263,48 +263,6 @@ void test_interval_comparisons() {
   static_assert(!(8000_ns <  t1     ));
   static_assert(!(t1      <  t2     ));
   
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS  
-  
-  static_assert(  t1      == 6       );
-  static_assert(  6       == t1      );
-  static_assert(!(t1      == 5      ));
-  static_assert(!(5       == t1     ));
-  
-  static_assert(!(t1      != 6      ));
-  static_assert(!(6       != t1     ));
-  static_assert(  t1      != 5       );
-  static_assert(  5       != t1      );
-  
-  static_assert(  t1      >= 6       );
-  static_assert(  6       >= t1      );
-  static_assert(  t1      >= 5       );
-  static_assert(!(5       >= t1     ));
-  static_assert(!(t1      >= 8      ));
-  static_assert(  8       >= t1      );
-  
-  static_assert(!(t1      >  6      ));
-  static_assert(!(6       >  t1     ));
-  static_assert(  t1      >  5       );
-  static_assert(!(5       >  t1     ));
-  static_assert(!(t1      >  8      ));
-  static_assert(  8       >  t1      );
-  
-  static_assert(  t1      <= 6       );
-  static_assert(  6       <= t1      );
-  static_assert(!(t1      <= 5      ));
-  static_assert(  5       <= t1      );
-  static_assert(  t1      <= 8       );
-  static_assert(!(8       <= t1     ));
-  
-  static_assert(!(t1      <  6      ));
-  static_assert(!(6       <  t1     ));
-  static_assert(!(t1      <  5      ));
-  static_assert(  5       <  t1      );
-  static_assert(  t1      <  8       );
-  static_assert(!(8       <  t1     ));
-  
-#endif // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS  
-  
 } // test_interval_comparisons()
 
 
@@ -326,15 +284,6 @@ void test_interval_queries() {
   static_assert(t2.quantity() == -4_us   );
   static_assert(t1.value()    ==     6.0 );
   static_assert(t2.value()    == -4000.0 );
-  
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION  
-  // implicit conversion
-  constexpr double const scalar_t1 = t1;
-  static_assert(scalar_t1 ==     6.0); // in microseconds
-  constexpr double const scalar_t2 = t2;
-  static_assert(scalar_t2 == -4000.0); // in nanoseconds
-#endif // LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION  
-  
   
 } // test_interval_queries()
 
@@ -537,48 +486,6 @@ void test_point_comparisons() {
   static_assert(!(8000_ns <  t1     ));
   static_assert(!(t1      <  t2     ));
   
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS  
-  
-  static_assert(  t1      == 6       );
-  static_assert(  6       == t1      );
-  static_assert(!(t1      == 5      ));
-  static_assert(!(5       == t1     ));
-  
-  static_assert(!(t1      != 6      ));
-  static_assert(!(6       != t1     ));
-  static_assert(  t1      != 5       );
-  static_assert(  5       != t1      );
-  
-  static_assert(  t1      >= 6       );
-  static_assert(  6       >= t1      );
-  static_assert(  t1      >= 5       );
-  static_assert(!(5       >= t1     ));
-  static_assert(!(t1      >= 8      ));
-  static_assert(  8       >= t1      );
-  
-  static_assert(!(t1      >  6      ));
-  static_assert(!(6       >  t1     ));
-  static_assert(  t1      >  5       );
-  static_assert(!(5       >  t1     ));
-  static_assert(!(t1      >  8      ));
-  static_assert(  8       >  t1      );
-  
-  static_assert(  t1      <= 6       );
-  static_assert(  6       <= t1      );
-  static_assert(!(t1      <= 5      ));
-  static_assert(  5       <= t1      );
-  static_assert(  t1      <= 8       );
-  static_assert(!(8       <= t1     ));
-  
-  static_assert(!(t1      <  6      ));
-  static_assert(!(6       <  t1     ));
-  static_assert(!(t1      <  5      ));
-  static_assert(  5       <  t1      );
-  static_assert(  t1      <  8       );
-  static_assert(!(8       <  t1     ));
-  
-#endif // LARDATAALG_UTILITIES_INTERVALS_ENABLE_VALUE_COMPARISONS  
-  
 } // test_point_comparisons()
 
 
@@ -600,14 +507,6 @@ void test_point_queries() {
   static_assert(t2.quantity() == -4_us   );
   static_assert(t1.value()    ==     6.0 );
   static_assert(t2.value()    == -4000.0 );
-  
-#ifdef LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION  
-  // implicit conversion
-  constexpr double const scalar_t1 = t1;
-  static_assert(scalar_t1 ==     6.0); // in microseconds
-  constexpr double const scalar_t2 = t2;
-  static_assert(scalar_t2 == -4000.0); // in nanoseconds
-#endif // LARDATAALG_UTILITIES_INTERVALS_ENABLE_IMPLICIT_CONVERSION  
   
 } // test_points_queries()
 

--- a/test/Utilities/intervals_test.cc
+++ b/test/Utilities/intervals_test.cc
@@ -22,12 +22,23 @@
 #include <type_traits>
 
 namespace {
-  template <typename T, typename U>
-  void
-  static_assert_type(U&&)
-  {
-    static_assert(std::is_same_v<T, U>);
-  }
+  template <typename T>
+  struct static_assert_type {
+    template <typename U>
+    explicit static_assert_type(U)
+    {
+      static_assert(std::is_same_v<T, U>);
+    }
+  };
+
+  template <typename T>
+  struct static_assert_type<T&> {
+    template <typename U>
+    explicit static_assert_type(U&)
+    {
+      static_assert(std::is_same_v<T&, U&>);
+    }
+  };
 }
 
 // -----------------------------------------------------------------------------
@@ -308,69 +319,69 @@ void test_interval_operations() {
   constexpr microseconds ct1 {    +6.0_us };
   constexpr microseconds ct2 { -4000.0_ns };
 
-  static_assert_type<microseconds>(ct1 + -4000.0_ns);
+  static_assert_type<microseconds>{ct1 + -4000.0_ns};
   static_assert(ct1 + -4000.0_ns == 2_us);
 
-  static_assert_type<microseconds>(ct1 + ct2);
+  static_assert_type<microseconds>{ct1 + ct2};
   static_assert(ct1 + ct2 == 2_us);
 
-  static_assert_type<microseconds>(ct1 - -4000.0_ns);
+  static_assert_type<microseconds>{ct1 - -4000.0_ns};
   static_assert(ct1 - -4000.0_ns == 10_us);
 
-  static_assert_type<microseconds>(ct1 - ct2);
+  static_assert_type<microseconds>{ct1 - ct2};
   static_assert(ct1 - ct2 == 10_us);
 
-  static_assert_type<microseconds>(+ct1);
+  static_assert_type<microseconds>{+ct1};
   static_assert(+ct1 == 6_us);
 
-  static_assert_type<microseconds>(-ct1);
+  static_assert_type<microseconds>{-ct1};
   static_assert(-ct1 == -6_us);
 
-  static_assert_type<microseconds>(ct1.abs());
+  static_assert_type<microseconds>{ct1.abs()};
   static_assert(ct1.abs() == 6_us);
   static_assert(ct2.abs() == 4_us);
 
-  static_assert_type<microseconds>(ct1 * 3.0);
+  static_assert_type<microseconds>{ct1 * 3.0};
   static_assert(ct1 * 3.0 == 6_us * 3.0);
 
-  static_assert_type<microseconds>(3.0 * ct1);
+  static_assert_type<microseconds>{3.0 * ct1};
   static_assert(3.0 * ct1 == 6_us * 3.0);
 
-  static_assert_type<microseconds>(ct1 / 2.0);
+  static_assert_type<microseconds>{ct1 / 2.0};
   static_assert(ct1 / 2.0 == 6_us / 2.0);
 
   microseconds t1      {    +6.0_us };
   nanoseconds const t2 { -4000.0_ns };
 
   decltype(auto) incr = (t1 += 2000_ns);
-  static_assert_type<microseconds&>(incr);
+  static_assert_type<microseconds&>{incr};
   BOOST_TEST(t1 == 8_us);
   BOOST_TEST(&incr == &t1);
 
   decltype(auto) incr2 = (t1 += t2);
-  static_assert_type<microseconds&>(incr2);
+  static_assert_type<microseconds&>{incr2};
   BOOST_TEST(t1 ==  4_us);
   BOOST_TEST(t2 == -4_us);
   BOOST_TEST(&incr2 == &t1);
 
   decltype(auto) decr = (t1 -= 2000_ns);
-  static_assert_type<microseconds&>(decr);
+  static_assert_type<microseconds&>{decr};
   BOOST_TEST(t1 == 2_us);
   BOOST_TEST(&decr == &t1);
 
   decltype(auto) decr2 = (t1 -= t2);
-  static_assert_type<microseconds&>(decr2);
+  static_assert_type<microseconds&>{decr2};
   BOOST_TEST(t1 ==  6_us);
   BOOST_TEST(t2 == -4_us);
   BOOST_TEST(&decr2 == &t1);
 
   decltype(auto) expand = (t1 *= 2);
-  static_assert_type<microseconds&>(expand);
+  static_assert_type<microseconds&>{expand};
   BOOST_TEST(t1 == 12_us);
   BOOST_TEST(&expand == &t1);
 
   decltype(auto) shrink = (t1 /= 2);
-  static_assert_type<microseconds&>(shrink);
+  static_assert_type<microseconds&>{shrink};
   BOOST_TEST(t1 == 6_us);
   BOOST_TEST(&shrink == &t1);
 
@@ -531,22 +542,22 @@ void test_point_operations() {
   constexpr microsecond cp1 {    +6.0_us };
   constexpr util::quantities::intervals::microseconds ct { 3.0_us };
 
-  static_assert_type<microsecond>(cp1 + 3000_ns);
+  static_assert_type<microsecond>{cp1 + 3000_ns};
   static_assert(cp1 + 3000_ns == 9_us);
 
-  static_assert_type<microsecond>(cp1 + ct);
+  static_assert_type<microsecond>{cp1 + ct};
   static_assert(cp1 + ct == 9_us);
 
-  static_assert_type<microsecond>(cp1 - 3000_ns);
+  static_assert_type<microsecond>{cp1 - 3000_ns};
   static_assert(cp1 - 3000_ns == 3_us);
 
-  static_assert_type<microsecond>(cp1 - ct);
+  static_assert_type<microsecond>{cp1 - ct};
   static_assert(cp1 - ct == 3_us);
 
-  static_assert_type<microsecond>(+cp1);
+  static_assert_type<microsecond>{+cp1};
   static_assert(+cp1 == 6_us);
 
-  static_assert_type<microsecond>(-cp1);
+  static_assert_type<microsecond>{-cp1};
   static_assert(-cp1 == -6_us);
 
   microsecond p1 {    +6.0_us };
@@ -554,30 +565,29 @@ void test_point_operations() {
   util::quantities::intervals::nanoseconds t { 3000.0_ns };
 
   decltype(auto) incr = (p1 += 2000_ns);
-  static_assert_type<microsecond&>(incr);
+  static_assert_type<microsecond&>{incr};
   BOOST_TEST(p1 == 8_us);
   BOOST_TEST(&incr == &p1);
 
   decltype(auto) incr2 = (p1 += t);
-  static_assert_type<microsecond&>(incr2);
+  static_assert_type<microsecond&>{incr2};
   BOOST_TEST(p1 == 11_us);
   BOOST_TEST(t ==   3_us);
   BOOST_TEST(&incr2 == &p1);
 
   decltype(auto) decr = (p1 -= 2000_ns);
-  static_assert_type<microsecond&>(decr);
+  static_assert_type<microsecond&>{decr};
   BOOST_TEST(p1 == 9_us);
   BOOST_TEST(&decr == &p1);
 
   decltype(auto) decr2 = (p1 -= t);
-  static_assert_type<microsecond&>(decr2);
+  static_assert_type<microsecond&>{decr2};
   BOOST_TEST(p1 ==  6_us);
   BOOST_TEST(t ==   3_us);
   BOOST_TEST(&decr2 == &p1);
 
   decltype(auto) diff = (p1 - p2);
-  static_assert
-   (std::is_same_v<decltype(diff), util::quantities::intervals::microseconds>);
+  static_assert_type<util::quantities::intervals::microseconds>{diff};
   BOOST_TEST(p1 ==  6_us);
   BOOST_TEST(p2 == -4_us);
   BOOST_TEST(diff == 10_us);

--- a/test/Utilities/intervals_test.cc
+++ b/test/Utilities/intervals_test.cc
@@ -15,6 +15,7 @@
 #include "lardataalg/Utilities/intervals.h"
 #include "lardataalg/Utilities/quantities/spacetime.h"
 #include "larcorealg/CoreUtils/DebugUtils.h" // lar::debug::static_assert_on<>()
+#include "test/Utilities/disable_boost_fpc_tolerance.hpp"
 
 
 // C/C++ standard libraries
@@ -151,35 +152,35 @@ static_assert(
 void test_interval_construction() {
 
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::intervals::microseconds;
   using util::quantities::intervals::nanoseconds;
-  
+
   microseconds ct0; // can't be constant since it's uninitialized
   (void) ct0; // don't let this fall unused
-  
+
   constexpr microseconds ct1 { 2.0 };
   static_assert(ct1.value() == 2.0);
-  
+
   constexpr microseconds ct2 { +6.0_us };
   static_assert(ct2.value() == 6.0);
-  
+
   constexpr microseconds ct3 { -4000.0_ns };
   static_assert(ct3.value() == -4.0);
-  
+
 } // void test_interval_construction()
 
 
 // -----------------------------------------------------------------------------
 void test_interval_comparisons() {
-  
+
   using namespace util::quantities::time_literals;
   using util::quantities::intervals::microseconds;
   using util::quantities::intervals::nanoseconds;
-  
+
   constexpr microseconds const t1 {         +6.0_us };
   constexpr nanoseconds  const t2 { -4'000'000.0_ps };
-  
+
   constexpr microseconds const t1s = t1;
 
   static_assert(  t1      == 6_us    );
@@ -192,7 +193,7 @@ void test_interval_comparisons() {
   static_assert(!(5_us    == t1     ));
   static_assert(!(5_ns    == t1     ));
   static_assert(!(t1      == t2     ));
-  
+
   static_assert(!(t1      != 6_us   ));
   static_assert(!(t1      != 6000_ns));
   static_assert(!(6_us    != t1     ));
@@ -203,7 +204,7 @@ void test_interval_comparisons() {
   static_assert(  5_us    != t1      );
   static_assert(  5_ns    != t1      );
   static_assert(  t1      != t2      );
-  
+
   static_assert(  t1      >= 6_us    );
   static_assert(  t1      >= 6000_ns );
   static_assert(  6_us    >= t1      );
@@ -218,7 +219,7 @@ void test_interval_comparisons() {
   static_assert(  8_us    >= t1      );
   static_assert(  8000_ns >= t1      );
   static_assert(  t1      >= t2      );
-  
+
   static_assert(!(t1      >  6_us   ));
   static_assert(!(t1      >  6000_ns));
   static_assert(!(6_us    >  t1     ));
@@ -233,7 +234,7 @@ void test_interval_comparisons() {
   static_assert(  8_us    >  t1      );
   static_assert(  8000_ns >  t1      );
   static_assert(  t1      >  t2      );
-  
+
   static_assert(  t1      <= 6_us    );
   static_assert(  t1      <= 6000_ns );
   static_assert(  6000_ns <= t1      );
@@ -247,7 +248,7 @@ void test_interval_comparisons() {
   static_assert(!(8_us    <= t1     ));
   static_assert(!(8000_ns <= t1     ));
   static_assert(!(t1      <= t2     ));
-  
+
   static_assert(!(t1      <  6_us   ));
   static_assert(!(t1      <  6000_ns));
   static_assert(!(6_us    <  t1     ));
@@ -262,29 +263,29 @@ void test_interval_comparisons() {
   static_assert(!(8_us    <  t1     ));
   static_assert(!(8000_ns <  t1     ));
   static_assert(!(t1      <  t2     ));
-  
+
 } // test_interval_comparisons()
 
 
 // -----------------------------------------------------------------------------
 void test_interval_queries() {
-  
+
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::intervals::microseconds;
   using util::quantities::intervals::nanoseconds;
-  
+
   constexpr microseconds t1 {         +6.0_us };
   constexpr nanoseconds  t2 { -4'000'000.0_ps };
-  
+
   static_assert(std::is_same_v<microseconds::quantity_t, util::quantities::microsecond>);
   static_assert(std::is_same_v<microseconds::unit_t, util::quantities::microsecond::unit_t>);
-  
+
   static_assert(t1.quantity() ==  6_us   );
   static_assert(t2.quantity() == -4_us   );
   static_assert(t1.value()    ==     6.0 );
   static_assert(t2.value()    == -4000.0 );
-  
+
 } // test_interval_queries()
 
 
@@ -292,13 +293,13 @@ void test_interval_queries() {
 void test_interval_operations() {
 
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::intervals::microseconds;
   using util::quantities::intervals::nanoseconds;
-  
+
   constexpr microseconds ct1 {    +6.0_us };
   constexpr microseconds ct2 { -4000.0_ns };
-  
+
   static_assert(std::is_same_v<decltype(ct1 + -4000.0_ns), microseconds>);
   static_assert(ct1 + -4000.0_ns == 2_us);
 
@@ -323,48 +324,42 @@ void test_interval_operations() {
 
   static_assert(std::is_same_v<decltype(ct1 * 3.0), microseconds>);
   static_assert(ct1 * 3.0 == 6_us * 3.0);
-  
+
   static_assert(std::is_same_v<decltype(3.0 * ct1), microseconds>);
   static_assert(3.0 * ct1 == 6_us * 3.0);
-  
+
   static_assert(std::is_same_v<decltype(ct1 / 2.0), microseconds>);
   static_assert(ct1 / 2.0 == 6_us / 2.0);
-  
+
   microseconds t1 {    +6.0_us };
   nanoseconds t2  { -4000.0_ns };
 
-  decltype(auto) incr = (t1 += 2000_ns);
-  static_assert(std::is_same_v<decltype(incr), microseconds&>);
-  BOOST_TEST((t1 == 8_us));
-  BOOST_TEST((&incr == &t1));
-  
-  decltype(auto) incr2 = (t1 += t2);
-  static_assert(std::is_same_v<decltype(incr2), microseconds&>);
-  BOOST_TEST((t1 ==  4_us));
-  BOOST_TEST((t2 == -4_us));
-  BOOST_TEST((&incr2 == &t1));
-  
-  decltype(auto) decr = (t1 -= 2000_ns);
-  static_assert(std::is_same_v<decltype(decr), microseconds&>);
-  BOOST_TEST((t1 == 2_us));
-  BOOST_TEST((&decr == &t1));
-  
-  decltype(auto) decr2 = (t1 -= t2);
-  static_assert(std::is_same_v<decltype(decr2), microseconds&>);
-  BOOST_TEST((t1 ==  6_us));
-  BOOST_TEST((t2 == -4_us));
-  BOOST_TEST((&decr2 == &t1));
-  
-  decltype(auto) expand = (t1 *= 2);
-  static_assert(std::is_same_v<decltype(expand), microseconds&>);
-  BOOST_TEST((t1 == 12_us));
-  BOOST_TEST((&expand == &t1));
-  
-  decltype(auto) shrink = (t1 /= 2);
-  static_assert(std::is_same_v<decltype(shrink), microseconds&>);
-  BOOST_TEST((t1 == 6_us));
-  BOOST_TEST((&shrink == &t1));
-  
+  microseconds& incr = (t1 += 2000_ns);
+  BOOST_TEST(t1 == 8_us);
+  BOOST_TEST(&incr == &t1);
+
+  microseconds& incr2 = (t1 += t2);
+  BOOST_TEST(t1 ==  4_us);
+  BOOST_TEST(t2 == -4_us);
+  BOOST_TEST(&incr2 == &t1);
+
+  microseconds& decr = (t1 -= 2000_ns);
+  BOOST_TEST(t1 == 2_us);
+  BOOST_TEST(&decr == &t1);
+
+  microseconds& decr2 = (t1 -= t2);
+  BOOST_TEST(t1 ==  6_us);
+  BOOST_TEST(t2 == -4_us);
+  BOOST_TEST(&decr2 == &t1);
+
+  microseconds& expand = (t1 *= 2);
+  BOOST_TEST(t1 == 12_us);
+  BOOST_TEST(&expand == &t1);
+
+  microseconds& shrink = (t1 /= 2);
+  BOOST_TEST(t1 == 6_us);
+  BOOST_TEST(&shrink == &t1);
+
 } // test_interval_operations()
 
 
@@ -374,22 +369,22 @@ void test_interval_operations() {
 void test_point_construction() {
 
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::points::microsecond;
   using util::quantities::points::nanosecond;
-  
+
   microsecond ct0;
   (void) ct0; // don't let this fall unused
-  
+
   constexpr microsecond ct1 { 2.0 };
   static_assert(ct1.value() == 2.0);
-  
+
   constexpr microsecond ct2 {    +6.0_us };
   static_assert(ct2.value() == 6.0);
-  
+
   constexpr microsecond ct3 { -4000.0_ns };
   static_assert(ct3.value() == -4.0);
-  
+
 } // void test_point_construction()
 
 
@@ -398,10 +393,10 @@ void test_point_comparisons() {
   using namespace util::quantities::time_literals;
   using util::quantities::points::microsecond;
   using util::quantities::points::nanosecond;
-  
+
   constexpr microsecond const t1 {         +6.0_us };
   constexpr nanosecond  const t2 { -4'000'000.0_ps };
-  
+
   constexpr microsecond const t1s = t1;
 
   static_assert(  t1      == 6_us    );
@@ -414,7 +409,7 @@ void test_point_comparisons() {
   static_assert(!(5_us    == t1     ));
   static_assert(!(5_ns    == t1     ));
   static_assert(!(t1      == t2     ));
-  
+
   static_assert(!(t1      != 6_us   ));
   static_assert(!(t1      != 6000_ns));
   static_assert(!(6_us    != t1     ));
@@ -425,7 +420,7 @@ void test_point_comparisons() {
   static_assert(  5_us    != t1      );
   static_assert(  5_ns    != t1      );
   static_assert(  t1      != t2      );
-  
+
   static_assert(  t1      >= 6_us    );
   static_assert(  t1      >= 6000_ns );
   static_assert(  6_us    >= t1      );
@@ -440,7 +435,7 @@ void test_point_comparisons() {
   static_assert(  8_us    >= t1      );
   static_assert(  8000_ns >= t1      );
   static_assert(  t1      >= t2      );
-  
+
   static_assert(!(t1      >  6_us   ));
   static_assert(!(t1      >  6000_ns));
   static_assert(!(6_us    >  t1     ));
@@ -455,7 +450,7 @@ void test_point_comparisons() {
   static_assert(  8_us    >  t1      );
   static_assert(  8000_ns >  t1      );
   static_assert(  t1      >  t2      );
-  
+
   static_assert(  t1      <= 6_us    );
   static_assert(  t1      <= 6000_ns );
   static_assert(  6_us    <= t1      );
@@ -470,7 +465,7 @@ void test_point_comparisons() {
   static_assert(!(8_us    <= t1     ));
   static_assert(!(8000_ns <= t1     ));
   static_assert(!(t1      <= t2     ));
-  
+
   static_assert(!(t1      <  6_us   ));
   static_assert(!(t1      <  6000_ns));
   static_assert(!(6_us    <  t1     ));
@@ -485,29 +480,29 @@ void test_point_comparisons() {
   static_assert(!(8_us    <  t1     ));
   static_assert(!(8000_ns <  t1     ));
   static_assert(!(t1      <  t2     ));
-  
+
 } // test_point_comparisons()
 
 
 // -----------------------------------------------------------------------------
 void test_point_queries() {
-  
+
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::points::microsecond;
   using util::quantities::points::nanosecond;
-  
+
   constexpr microsecond t1 {         +6.0_us };
   constexpr nanosecond  t2 { -4'000'000.0_ps };
-  
+
   static_assert(std::is_same_v<microsecond::quantity_t, util::quantities::microsecond>);
   static_assert(std::is_same_v<microsecond::unit_t, util::quantities::microsecond::unit_t>);
-  
+
   static_assert(t1.quantity() ==  6_us   );
   static_assert(t2.quantity() == -4_us   );
   static_assert(t1.value()    ==     6.0 );
   static_assert(t2.value()    == -4000.0 );
-  
+
 } // test_points_queries()
 
 
@@ -515,13 +510,13 @@ void test_point_queries() {
 void test_point_operations() {
 
   using namespace util::quantities::time_literals;
- 
+
   using util::quantities::points::microsecond;
   using util::quantities::points::nanosecond;
-  
+
   constexpr microsecond cp1 {    +6.0_us };
   constexpr util::quantities::intervals::microseconds ct { 3.0_us };
-  
+
   static_assert(std::is_same_v<decltype(cp1 + 3000_ns), microsecond>);
   static_assert(cp1 + 3000_ns == 9_us);
 
@@ -544,35 +539,31 @@ void test_point_operations() {
   microsecond p2 { -4000.0_ns };
   util::quantities::intervals::nanoseconds t { 3000.0_ns };
 
-  decltype(auto) incr = (p1 += 2000_ns);
-  static_assert(std::is_same_v<decltype(incr), microsecond&>);
-  BOOST_TEST((p1 == 8_us));
-  BOOST_TEST((&incr == &p1));
-  
-  decltype(auto) incr2 = (p1 += t);
-  static_assert(std::is_same_v<decltype(incr2), microsecond&>);
-  BOOST_TEST((p1 == 11_us));
-  BOOST_TEST((t ==   3_us));
-  BOOST_TEST((&incr2 == &p1));
-  
-  decltype(auto) decr = (p1 -= 2000_ns);
-  static_assert(std::is_same_v<decltype(decr), microsecond&>);
-  BOOST_TEST((p1 == 9_us));
-  BOOST_TEST((&decr == &p1));
-  
-  decltype(auto) decr2 = (p1 -= t);
-  static_assert(std::is_same_v<decltype(decr2), microsecond&>);
-  BOOST_TEST((p1 ==  6_us));
-  BOOST_TEST((t ==   3_us));
-  BOOST_TEST((&decr2 == &p1));
-  
+  microsecond& incr = (p1 += 2000_ns);
+  BOOST_TEST(p1 == 8_us);
+  BOOST_TEST(&incr == &p1);
+
+  microsecond& incr2 = (p1 += t);
+  BOOST_TEST(p1 == 11_us);
+  BOOST_TEST(t ==   3_us);
+  BOOST_TEST(&incr2 == &p1);
+
+  microsecond& decr = (p1 -= 2000_ns);
+  BOOST_TEST(p1 == 9_us);
+  BOOST_TEST(&decr == &p1);
+
+  microsecond& decr2 = (p1 -= t);
+  BOOST_TEST(p1 ==  6_us);
+  BOOST_TEST(t ==   3_us);
+  BOOST_TEST(&decr2 == &p1);
+
   decltype(auto) diff = (p1 - p2);
   static_assert
    (std::is_same_v<decltype(diff), util::quantities::intervals::microseconds>);
-  BOOST_TEST((p1 ==  6_us));
-  BOOST_TEST((p2 == -4_us));
-  BOOST_TEST((diff == 10_us));
-  
+  BOOST_TEST(p1 ==  6_us);
+  BOOST_TEST(p2 == -4_us);
+  BOOST_TEST(diff == 10_us);
+
 } // test_point_operations()
 
 

--- a/test/Utilities/quantities_fhicl_test.cc
+++ b/test/Utilities/quantities_fhicl_test.cc
@@ -14,6 +14,7 @@
 // LArSoft libraries
 #include "lardataalg/Utilities/quantities/spacetime.h"
 #include "lardataalg/Utilities/quantities_fhicl.h"
+#include "test/Utilities/disable_boost_fpc_tolerance.hpp"
 
 // support libraries
 #include "fhiclcpp/types/Table.h"
@@ -28,7 +29,7 @@
 template <typename Config>
 fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
   fhicl::Table<Config> validatedConfig { fhicl::Name("validatedConfig") };
-  
+
   std::cout << std::string(80, '-') << std::endl;
   std::cout << "===> FHiCL configuration:";
   if (pset.is_empty()) std::cout << " <empty>";
@@ -37,7 +38,7 @@ fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
   validatedConfig.print_allowed_configuration
     (std::cout << "===> Expected configuration: ");
   std::cout << std::endl;
-  
+
   validatedConfig.validate_ParameterSet(pset);
   return validatedConfig;
 } // validateConfig()
@@ -46,8 +47,7 @@ fhicl::Table<Config> validateConfig(fhicl::ParameterSet const& pset) {
 // -----------------------------------------------------------------------------
 template <typename Config>
 fhicl::Table<Config> validateConfig(std::string const& configStr) {
-  fhicl::ParameterSet pset;
-  pset = fhicl::ParameterSet::make(configStr);
+  auto pset = fhicl::ParameterSet::make(configStr);
   return validateConfig<Config>(pset);
 } // validateConfig(Config)
 
@@ -63,15 +63,15 @@ void test_makeQuantity() {
 
   auto t = util::quantities::makeQuantity<microsecond>("-7e1 ms"sv);
   static_assert(std::is_same_v<decltype(t), microsecond>);
-  BOOST_TEST((t == -70000_us));
-  BOOST_TEST((t == -70_ms));
+  BOOST_TEST(t == -70000_us);
+  BOOST_TEST(t == -70_ms);
 
   t = util::quantities::makeQuantity<microsecond>("7e1ms"sv);
-  BOOST_TEST((t == 70000_us));
-  BOOST_TEST((t == 70_ms));
+  BOOST_TEST(t == 70000_us);
+  BOOST_TEST(t == 70_ms);
 
   t = util::quantities::makeQuantity<microsecond>("7e1"sv, true);
-  BOOST_TEST((t == 70_us));
+  BOOST_TEST(t == 70_us);
 
   BOOST_CHECK_THROW(
     util::quantities::makeQuantity<microsecond>("7e1"sv),
@@ -103,68 +103,56 @@ void test_makeQuantity() {
 
 // -----------------------------------------------------------------------------
 void test_readQuantity() {
-  
+
   using namespace util::quantities::time_literals;
   using util::quantities::microsecond;
-  
+
   struct Config {
-    
+
     fhicl::Atom<util::quantities::microsecond> start
       { fhicl::Name("start"), 0_us };
-    
+
     fhicl::Atom<util::quantities::microsecond> end
       { fhicl::Name("end"), 6_ms };
-    
+
   }; // struct Config
-  
+
   std::string const configStr { "end: 16ms" };
   util::quantities::microsecond const expectedStart = 0_us;
   util::quantities::microsecond const expectedEnd = 16_ms;
-  
+
   auto validatedConfig = validateConfig<Config>(configStr)();
-  
-  auto start = validatedConfig.start();
-  static_assert(std::is_same_v<decltype(start), util::quantities::microsecond>);
-  BOOST_TEST((start == expectedStart));
-  
-  auto end = validatedConfig.end();
-  static_assert(std::is_same_v<decltype(end), util::quantities::microsecond>);
-  BOOST_TEST((end == expectedEnd));
-  
+  BOOST_TEST(validatedConfig.start() == expectedStart);
+  BOOST_TEST(validatedConfig.end() == expectedEnd);
+
 } // test_readQuantity()
 
 
 // -----------------------------------------------------------------------------
 void test_writeQuantity() {
-  
+
   using namespace util::quantities::time_literals;
   using util::quantities::microsecond;
-  
+
   struct Config {
-    
+
     fhicl::Atom<util::quantities::microsecond> start
       { fhicl::Name("start"), 0_us };
-    
+
     fhicl::Atom<util::quantities::microsecond> end
       { fhicl::Name("end"), 6_ms };
-    
+
   }; // struct Config
-  
+
   fhicl::ParameterSet pset;
   pset.put<util::quantities::microsecond>("end", 16_ms);
   util::quantities::microsecond const expectedStart = 0_us;
   util::quantities::microsecond const expectedEnd = 16_ms;
-  
+
   auto validatedConfig = validateConfig<Config>(pset)();
-  
-  auto start = validatedConfig.start();
-  static_assert(std::is_same_v<decltype(start), util::quantities::microsecond>);
-  BOOST_TEST((start == expectedStart));
-  
-  auto end = validatedConfig.end();
-  static_assert(std::is_same_v<decltype(end), util::quantities::microsecond>);
-  BOOST_TEST((end == expectedEnd));
-  
+  BOOST_TEST(validatedConfig.start() == expectedStart);
+  BOOST_TEST(validatedConfig.end() == expectedEnd);
+
 } // test_writeQuantity()
 
 

--- a/test/Utilities/quantities_test.cc
+++ b/test/Utilities/quantities_test.cc
@@ -15,10 +15,12 @@
 #include "lardataalg/Utilities/quantities/spacetime.h"
 #include "lardataalg/Utilities/quantities.h"
 #include "larcorealg/CoreUtils/StdUtils.h" // util::to_string()
+#include "test/Utilities/disable_boost_fpc_tolerance.hpp"
 
 // C/C++ standard libraries
 #include <type_traits> // std::decay_t<>
 
+using boost::test_tools::tolerance;
 
 // -----------------------------------------------------------------------------
 // --- implementation detail tests
@@ -120,22 +122,22 @@ void test_quantities_sign() {
 
   util::quantities::microseconds t { -4.0 };
 
-  BOOST_TEST((t == -4_us)); // just to be safe
+  BOOST_TEST(t == -4_us); // just to be safe
   static_assert(
     std::is_same<decltype(+t), util::quantities::microseconds>(),
     "Positive sign converts to a different type!"
     );
-  BOOST_TEST((+t == -4_us));
+  BOOST_TEST(+t == -4_us);
   static_assert(
     std::is_same<decltype(-t), util::quantities::microseconds>(),
     "Negative sign converts to a different type!"
     );
-  BOOST_TEST((-t == 4_us));
+  BOOST_TEST(-t == 4_us);
   static_assert(
     std::is_same<decltype(t.abs()), util::quantities::microseconds>(),
     "Negative sign converts to a different type!"
     );
-  BOOST_TEST((t.abs() == 4.0_us));
+  BOOST_TEST(t.abs() == 4.0_us);
 
 } // test_quantities_sign()
 
@@ -150,21 +152,21 @@ void test_quantities_conversions() {
   //
   util::quantities::seconds t_s { 7.0 };
 
-  BOOST_TEST((t_s.value() == 7.0));
+  BOOST_TEST(t_s.value() == 7.0);
 
   util::quantities::microseconds t_us(t_s);
   t_us = t_s;
-  BOOST_TEST((t_us == 7'000'000.0_us));
+  BOOST_TEST(t_us == 7'000'000.0_us);
 
   util::quantities::seconds t(t_us);
-  BOOST_TEST((t == 7.0_s));
+  BOOST_TEST(t == 7.0_s);
 
   static_assert(std::is_same<
     decltype(t.convertInto<util::quantities::microseconds>()),
     util::quantities::microseconds
     >());
   BOOST_TEST
-    ((t.convertInto<util::quantities::microseconds>() == 7'000'000_us));
+    (t.convertInto<util::quantities::microseconds>() == 7'000'000_us);
 
 } // test_quantities_conversions()
 
@@ -175,7 +177,7 @@ void test_quantities_comparisons() {
   // comparisons between quantities
   //
   util::quantities::microseconds t_us { 7.0 };
-  BOOST_TEST( (t_us == t_us));
+  BOOST_TEST(  t_us == t_us);
   BOOST_TEST(!(t_us != t_us));
   BOOST_TEST( (t_us >= t_us));
   BOOST_TEST( (t_us <= t_us));
@@ -183,7 +185,7 @@ void test_quantities_comparisons() {
   BOOST_TEST(!(t_us <  t_us));
 
   util::quantities::nanoseconds  t_ns { 7.0 };
-  BOOST_TEST( (t_us != t_ns));
+  BOOST_TEST(  t_us != t_ns);
   BOOST_TEST(!(t_us == t_ns));
   BOOST_TEST( (t_us != t_ns));
   BOOST_TEST( (t_us >= t_ns));
@@ -192,14 +194,14 @@ void test_quantities_comparisons() {
   BOOST_TEST(!(t_us <  t_ns));
 
   util::quantities::nanoseconds t2_ns { 7000.0 };
-  BOOST_TEST( (t_us == t2_ns));
+  BOOST_TEST(  t_us == t2_ns);
   BOOST_TEST(!(t_us != t2_ns));
   BOOST_TEST( (t_us >= t2_ns));
   BOOST_TEST( (t_us <= t2_ns));
   BOOST_TEST(!(t_us >  t2_ns));
   BOOST_TEST(!(t_us <  t2_ns));
 
-  BOOST_TEST( (t_ns != t2_ns));
+  BOOST_TEST(  t_ns != t2_ns);
   BOOST_TEST(!(t_ns == t2_ns));
   BOOST_TEST( (t_ns != t2_ns));
   BOOST_TEST(!(t_ns >= t2_ns));
@@ -228,7 +230,7 @@ void test_quantities_multiply_scalar() {
       <std::decay_t<decltype(twice_t)>, util::quantities::seconds>(),
     "Multiplication by a scalar converts to a different type!"
     );
-  BOOST_TEST((twice_t == 6.0_s));
+  BOOST_TEST(twice_t == 6.0_s);
 
   auto const t_twice = t * 2.0;
   static_assert(
@@ -236,25 +238,25 @@ void test_quantities_multiply_scalar() {
       <std::decay_t<decltype(t_twice)>, util::quantities::seconds>(),
     "Multiplication by a scalar converts to a different type!"
     );
-  BOOST_TEST((twice_t == 6.0_s));
+  BOOST_TEST(twice_t == 6.0_s);
 
   static_assert(
     std::is_same<decltype(twice_t / 2.0), util::quantities::seconds>(),
     "Division by a scalar converts to a different type!"
     );
-  BOOST_TEST((twice_t / 2.0 == 3.0_s));
+  BOOST_TEST(twice_t / 2.0 == 3.0_s);
 
   static_assert(
     std::is_same<decltype(twice_t / t), double>(),
     "Division by a scalar is not the base type!"
     );
-  BOOST_TEST((twice_t / t == 2.0));
+  BOOST_TEST(twice_t / t == 2.0);
 
   static_assert(
     std::is_same<decltype(t / 300_us), double>(),
     "Division by a scalar is not the base type!"
     );
-  BOOST_TEST((t / 300_us == 10'000.0));
+  BOOST_TEST(t / 300_us == 10'000.0);
 
 } // test_quantities_multiply_scalar()
 
@@ -276,13 +278,13 @@ void test_quantities_addition() {
     std::is_same<std::decay_t<decltype(45_s + 5_s)>, util::quantities::seconds>(),
     "Addition converts to a different type!"
     );
-  BOOST_TEST((45_s + 5_s == 50_s));
+  BOOST_TEST(45_s + 5_s == 50_s);
 
   static_assert(
     std::is_same<decltype(5_s - 55_s), util::quantities::seconds>(),
     "Subtraction converts to a different type!"
     );
-  BOOST_TEST((5_s - 55_s == -50_s));
+  BOOST_TEST(5_s - 55_s == -50_s);
 
 
   constexpr util::quantities::seconds t = 45_s;
@@ -291,15 +293,15 @@ void test_quantities_addition() {
       <std::decay_t<decltype(t.plus(5000_ms))>, util::quantities::seconds>(),
     "Addition converts to a different type!"
     );
-  BOOST_TEST((t.plus(5000_ms) == 50_s));
-  BOOST_TEST((t == 45_s));
+  BOOST_TEST(t.plus(5000_ms) == 50_s);
+  BOOST_TEST(t == 45_s);
 
   static_assert(
     std::is_same<decltype(t.minus(55000_ms)), util::quantities::seconds>(),
     "Subtraction converts to a different type!"
     );
-  BOOST_TEST((t.minus(55000_ms) == -10_s));
-  BOOST_TEST((t == 45_s));
+  BOOST_TEST(t.minus(55000_ms) == -10_s);
+  BOOST_TEST(t == 45_s);
 
 
 } // test_quantities_addition()
@@ -320,28 +322,28 @@ void test_quantities_increment() {
     std::is_same<decltype(t += 0.05_s), util::quantities::seconds&>(),
     "Increment converts to a different type!"
     );
-  BOOST_TEST((t == 0.1_s));
+  BOOST_TEST(t == 0.1_s);
 
   t -= 0.05_s;
   static_assert(
     std::is_same<decltype(t -= 0.05_s), util::quantities::seconds&>(),
     "Decrement converts to a different type!"
     );
-  BOOST_TEST((t == 0.05_s));
+  BOOST_TEST(t == 0.05_s);
 
   t += 50_ms;
   static_assert(
     std::is_same<decltype(t += 50_ms), util::quantities::seconds&>(),
     "Increment converts to a different type!"
     );
-  BOOST_TEST((t == 0.1_s));
+  BOOST_TEST(t == 0.1_s);
 
   t -= 50_ms;
   static_assert(
     std::is_same<decltype(t -= 50_ms), util::quantities::seconds&>(),
     "Decrement converts to a different type!"
     );
-  BOOST_TEST((t == 0.05_s));
+  BOOST_TEST(t == 0.05_s);
 
 } // test_quantities_multiply_scalar()
 
@@ -360,14 +362,14 @@ void test_quantities_scale() {
     std::is_same<decltype(t *= 2.0), util::quantities::microseconds&>(),
     "Scaling converts to a different type!"
     );
-  BOOST_TEST((t == 22.0_us));
+  BOOST_TEST(t == 22.0_us);
 
   t /= 2.0;
   static_assert(
     std::is_same<decltype(t /= 2.0), util::quantities::microseconds&>(),
     "Scaling (division) converts to a different type!"
     );
-  BOOST_TEST((t == 11.0_us));
+  BOOST_TEST(t == 11.0_us);
 
 } // test_quantities_scale()
 
@@ -385,8 +387,8 @@ void test_quantities_literals() {
 
   util::quantities::microsecond t3;
   t3 = 7.0_s;
-  BOOST_TEST((t3.value() == 7000000.0));
-  BOOST_TEST((t3 == 7000000_us));
+  BOOST_TEST(t3.value() == 7000000.0);
+  BOOST_TEST(t3 == 7000000_us);
 
   static_assert(7000000_us == 7_s, "Literal conversion failed.");
 
@@ -409,15 +411,15 @@ void test_quantities() {
   //
 //  t1 = 4.0; // error!
   t1 = util::quantities::microseconds { 4.0 };
-  BOOST_TEST((util::to_string(t1.unit()) == "us"));
-  BOOST_TEST((util::to_string(t1) == "4.000000 us"));
-  BOOST_TEST((t1.value() == 4.0));
+  BOOST_TEST(util::to_string(t1.unit()) == "us");
+  BOOST_TEST(util::to_string(t1) == "4.000000 us");
+  BOOST_TEST(t1.value() == 4.0);
 
   // ---------------------------------------------------------------------------
   // value constructor
   //
   util::quantities::microseconds t2 { 7.0 };
-  BOOST_TEST((t2 == 7.0_us));
+  BOOST_TEST(t2 == 7.0_us);
 
 
   // ---------------------------------------------------------------------------
@@ -483,59 +485,61 @@ void test_constexpr_operations() {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void test_makeQuantity() {
-  
+
   using namespace util::quantities::time_literals;
   using util::quantities::milliseconds;
-  
+
   constexpr auto expected = 3.0_ms;
   static_assert(std::is_same<std::decay_t<decltype(expected)>, milliseconds>());
-  
+
   auto q = util::quantities::makeQuantity<milliseconds>("3.0 ms");
   static_assert(std::is_same<std::decay_t<decltype(q)>, milliseconds>());
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+
+  auto const tol = 1e-7% tolerance();
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("  3.0ms  ");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("3ms");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("3000 us");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("0.03e+2 ms");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("+3ms");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("+3E-3s");
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("3", true);
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("3.0", true);
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   q = util::quantities::makeQuantity<milliseconds>("30e-1", true);
-  BOOST_CHECK_CLOSE(q.value(), expected.value(), 1e-7);
-  
+  BOOST_TEST(q.value() == expected.value(), tol);
+
   BOOST_CHECK_THROW(util::quantities::makeQuantity<milliseconds>("3"),
                     util::quantities::MissingUnit);
-  
+
   BOOST_CHECK_THROW(util::quantities::makeQuantity<milliseconds>("3 kg"),
                     util::quantities::MissingUnit);
-  
+
   BOOST_CHECK_THROW(util::quantities::makeQuantity<milliseconds>("3 dumbs"),
                     util::quantities::ExtraCharactersError);
-  
+
   BOOST_CHECK_THROW(util::quantities::makeQuantity<milliseconds>("three ms"),
                     util::quantities::ValueError);
-  
+
   BOOST_CHECK_THROW(util::quantities::makeQuantity<milliseconds>("3.zero ms"),
                     util::quantities::ExtraCharactersError);
-  
+
 } // test_makeQuantity()
 
 
@@ -556,7 +560,7 @@ BOOST_AUTO_TEST_CASE(quantities_testcase) {
   test_quantities_literals();
 
   test_constexpr_operations();
-  
+
   test_makeQuantity();
 
 } // BOOST_AUTO_TEST_CASE(quantities_testcase)

--- a/test/Utilities/quantities_test.cc
+++ b/test/Utilities/quantities_test.cc
@@ -207,104 +207,6 @@ void test_quantities_comparisons() {
   BOOST_TEST(!(t_ns >  t2_ns));
   BOOST_TEST( (t_ns <  t2_ns));
 
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
-  //
-  // comparisons between quantity and base value number
-  //
-  BOOST_TEST( (t_us != 8.0));
-  BOOST_TEST(!(t_us == 8.0));
-  BOOST_TEST( (t_us != 8.0));
-  BOOST_TEST(!(t_us >= 8.0));
-  BOOST_TEST( (t_us <= 8.0));
-  BOOST_TEST(!(t_us >  8.0));
-  BOOST_TEST( (t_us <  8.0));
-
-  BOOST_TEST( (t_us == 7.0));
-  BOOST_TEST(!(t_us != 7.0));
-  BOOST_TEST( (t_us >= 7.0));
-  BOOST_TEST( (t_us <= 7.0));
-  BOOST_TEST(!(t_us >  7.0));
-  BOOST_TEST(!(t_us <  7.0));
-
-  BOOST_TEST( (t_us != 6.0));
-  BOOST_TEST(!(t_us == 6.0));
-  BOOST_TEST( (t_us != 6.0));
-  BOOST_TEST( (t_us >= 6.0));
-  BOOST_TEST(!(t_us <= 6.0));
-  BOOST_TEST( (t_us >  6.0));
-  BOOST_TEST(!(t_us <  6.0));
-
-  BOOST_TEST(!(8.0 == t_us));
-  BOOST_TEST( (8.0 != t_us));
-  BOOST_TEST( (8.0 >= t_us));
-  BOOST_TEST(!(8.0 <= t_us));
-  BOOST_TEST( (8.0 >  t_us));
-  BOOST_TEST(!(8.0 <  t_us));
-
-  BOOST_TEST( (7.0 == t_us));
-  BOOST_TEST(!(7.0 != t_us));
-  BOOST_TEST( (7.0 >= t_us));
-  BOOST_TEST( (7.0 <= t_us));
-  BOOST_TEST(!(7.0 >  t_us));
-  BOOST_TEST(!(7.0 <  t_us));
-
-  BOOST_TEST(!(6.0 == t_us));
-  BOOST_TEST( (6.0 != t_us));
-  BOOST_TEST(!(6.0 >= t_us));
-  BOOST_TEST( (6.0 <= t_us));
-  BOOST_TEST(!(6.0 >  t_us));
-  BOOST_TEST( (6.0 <  t_us));
-
-  //
-  // comparisons between quantity and number
-  //
-  BOOST_TEST( (t_us != 8));
-  BOOST_TEST(!(t_us == 8));
-  BOOST_TEST( (t_us != 8));
-  BOOST_TEST(!(t_us >= 8));
-  BOOST_TEST( (t_us <= 8));
-  BOOST_TEST(!(t_us >  8));
-  BOOST_TEST( (t_us <  8));
-
-  BOOST_TEST( (t_us == 7));
-  BOOST_TEST(!(t_us != 7));
-  BOOST_TEST( (t_us >= 7));
-  BOOST_TEST( (t_us <= 7));
-  BOOST_TEST(!(t_us >  7));
-  BOOST_TEST(!(t_us <  7));
-
-  BOOST_TEST( (t_us != 6));
-  BOOST_TEST(!(t_us == 6));
-  BOOST_TEST( (t_us != 6));
-  BOOST_TEST( (t_us >= 6));
-  BOOST_TEST(!(t_us <= 6));
-  BOOST_TEST( (t_us >  6));
-  BOOST_TEST(!(t_us <  6));
-
-  BOOST_TEST(!(8 == t_us));
-  BOOST_TEST( (8 != t_us));
-  BOOST_TEST( (8 >= t_us));
-  BOOST_TEST(!(8 <= t_us));
-  BOOST_TEST( (8 >  t_us));
-  BOOST_TEST(!(8 <  t_us));
-
-  BOOST_TEST( (7 == t_us));
-  BOOST_TEST(!(7 != t_us));
-  BOOST_TEST( (7 >= t_us));
-  BOOST_TEST( (7 <= t_us));
-  BOOST_TEST(!(7 >  t_us));
-  BOOST_TEST(!(7 <  t_us));
-
-  BOOST_TEST(!(6 == t_us));
-  BOOST_TEST( (6 != t_us));
-  BOOST_TEST(!(6 >= t_us));
-  BOOST_TEST( (6 <= t_us));
-  BOOST_TEST(!(6 >  t_us));
-  BOOST_TEST( (6 <  t_us));
-
-#endif // LARDATAALG_UTILITIES_QUANTITIES_ENABLE_VALUE_COMPARISONS
-
 } // test_quantities_conversions()
 
 
@@ -535,9 +437,6 @@ void test_constexpr_operations() {
 
   static_assert(t1.value() == 10.0, "value()");
   static_assert(double(t1) == 10.0, "explicit conversion to plain number");
-#ifdef LARDATAALG_UTILITIES_QUANTITIES_ENABLE_IMPLICIT_CONVERSION
-  static_assert(t1 == 10.0, "implicit conversion to plain number");
-#endif
   static_assert(+t1 == 10_us, "unary +");
   static_assert(-t1 == -10_us, "unary -");
   static_assert(t1.abs() == 10_us, "abs()");


### PR DESCRIPTION
As part of https://cdcvs.fnal.gov/redmine/issues/26092. No breaking changes.