### PR TITLE
Fixed bug in detinfo::DetectorTimings::BeamGateTime()

### DIFF
--- a/lardataalg/DetectorInfo/DetectorTimings.h
+++ b/lardataalg/DetectorInfo/DetectorTimings.h
@@ -338,7 +338,7 @@ namespace detinfo {
     electronics_time
     BeamGateTime() const
     {
-      return electronics_time{detClocksUnits().TriggerTime()};
+      return electronics_time{detClocksUnits().BeamGateTime()};
     }
 
     // --- END -- Electronics times --------------------------------------------


### PR DESCRIPTION
Nasty copy&paste error fixed.

Presumably it god unnoticed for two years (i.e. from its inception) because:
* beam and trigger time are typically different only in real data, and trigger simulation is apparently not very popular in LAr
* unit test also uses simulation-style settings
* MicroBooNE (i.e. who has data) does not use `detinfo::DetectorClocks` because it's too new

Anyway, the ride of this one ends here.