### PR TITLE
Add a new parameter controlling whether or not to allow for timing offsets between the different readout planes

### DIFF
--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
@@ -114,6 +114,15 @@ namespace detinfo {
                 "model for velocity calculation as in arXiv:2008.09765"),
         false};
 
+      fhicl::Atom<bool> IncludeInterPlanePitchInXTickOffsets{
+        Name("IncludeInterPlanePitchInXTickOffsets"),
+        Comment("Historically, ConvertTicksToX has allowed for the drift time "
+                "between the wire planes. This is appropriate for "
+                "recob::RawDigits, and recob::Wires from the 1D unfolding, "
+                "but is not appropriate for recob::Wires from WireCell. "
+                "The default value is 'true', retaining the 'classic' behaviour"),
+        true};
+
       fhicl::Atom<bool> SimpleBoundary{Name("SimpleBoundaryProcess"), Comment("")};
 
     }; // Configuration_t
@@ -291,6 +300,12 @@ namespace detinfo {
 
     bool fUseIcarusMicrobooneDriftModel; ///< if true, use alternative ICARUS-MicroBooNE drift
                                          ///< model instead of Walkowiak-based one
+
+    /// Historically, ConvertTicksToX has allowed for the drift time between
+    /// the wire planes. This is appropriate for recob::RawDigits, and
+    /// recob::Wires from the 1D unfolding, but is not appropriate for
+    /// recob::Wires from WireCell.
+    bool fIncludeInterPlanePitchInXTickOffsets;
 
     SternheimerParameters_t fSternheimerParameters; ///< Sternheimer parameters
 

--- a/lardataalg/DetectorInfo/detectorproperties.fcl
+++ b/lardataalg/DetectorInfo/detectorproperties.fcl
@@ -18,7 +18,13 @@ standard_detproperties :
  DriftVelFudgeFactor: 1.
 
  UseIcarusMicrobooneDriftModel: false # if true, use alternative drift velocity formulation
- 
+
+ # Historically, ConvertTicksToX has allowed for the drift time between the
+ # wire planes. This is appropriate for recob::RawDigits, and recob::Wires from
+ # the 1D unfolding, but is not appropriate for recob::Wires from WireCell. The
+ # default value is 'true', retaining the 'classic' behaviour.
+ IncludeInterPlanePitchInXTickOffsets: true
+
  ElectronsToADC:    1.208041e-3  # in ADC/e; 6241.5 electrons = 1fC = 7.54 ADC counts for ArgoNeuT
  NumberTimeSamples: 2048         # ticks of the clock per readout frame
  TimeOffsetU:       -5.193


### PR DESCRIPTION
This is a pragmatic short-term solution while we work out how to encode this information somewhere such that no such switch is necessary.

I think the main thing to be debated here is the variable name / comment. I went for the most literal code-level name, because I couldn't think of a succinct way of capturing the content.

Given the default value, this ought to have no observable effect on anyone, but it gives DUNE an easy knob to turn to reproduce the behaviour that is currently in the hacked ProtoDUNE service.

Looking at the code, I don't think it's necessarily treating the collection plane as the origin, rather whatever `TPCGeo::PlaneLocation()` returns, which the comments imply might be the grid plane? In any case, the toggle will treat all planes the same, and the same as we had them in ProtoDUNE. Any remaining small _absolute_ offset is less significant.