### PR TITLE
Migrate to Cetmodules 3.12.00 and modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,20 @@ cet_set_compiler_flags(DIAGS CAUTIOUS
 
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
-find_package(cetlib_except REQUIRED EXPORT)
-find_package(cetlib REQUIRED EXPORT)
-find_package(canvas REQUIRED EXPORT)
-find_package(canvas_root_io REQUIRED)
 find_package(nusimdata REQUIRED EXPORT)
-find_package(ROOT COMPONENTS Core EG Hist REQUIRED EXPORT)
-find_package(Boost REQUIRED)
-find_package( larcoreobj REQUIRED EXPORT)
-find_package( larcorealg REQUIRED EXPORT)
-find_package( lardataobj REQUIRED EXPORT)
+
+find_package(canvas REQUIRED EXPORT)
+find_package(messagefacility REQUIRED EXPORT)
+find_package(fhiclcpp REQUIRED EXPORT)
+find_package(cetlib REQUIRED EXPORT)
+find_package(cetlib_except REQUIRED EXPORT)
+
+find_package(Boost COMPONENTS headers REQUIRED EXPORT)
+find_package(ROOT COMPONENTS Core EG Hist Physics REQUIRED EXPORT)
+
+find_package(lardataobj REQUIRED EXPORT)
+find_package(larcorealg REQUIRED EXPORT)
+find_package(larcoreobj REQUIRED EXPORT)
 
 # source
 add_subdirectory(lardataalg)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,120 @@
+{
+   "configurePresets" : [
+      {
+         "cacheVariables" : {
+            "CMAKE_BUILD_TYPE" : {
+               "type" : "STRING",
+               "value" : "RelWithDebInfo"
+            },
+            "CMAKE_CXX_EXTENSIONS" : {
+               "type" : "BOOL",
+               "value" : "OFF"
+            },
+            "CMAKE_CXX_STANDARD_REQUIRED" : {
+               "type" : "BOOL",
+               "value" : "ON"
+            },
+            "lardataalg_ADD_NOARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "FHICL_DIR"
+            },
+            "lardataalg_FHICL_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "job"
+            }
+         },
+         "description" : "Configuration settings translated from ups/product_deps",
+         "displayName" : "Configuration from product_deps",
+         "hidden" : true,
+         "name" : "from_product_deps"
+      },
+      {
+         "cacheVariables" : {
+            "CMAKE_CXX_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER}"
+            },
+            "CMAKE_CXX_STANDARD" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_STANDARD}"
+            },
+            "CMAKE_C_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER}"
+            },
+            "CMAKE_Fortran_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER}"
+            },
+            "UPS_CXX_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_ID}"
+            },
+            "UPS_CXX_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_VERSION}"
+            },
+            "UPS_C_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_ID}"
+            },
+            "UPS_C_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_VERSION}"
+            },
+            "UPS_Fortran_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_ID}"
+            },
+            "UPS_Fortran_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_VERSION}"
+            },
+            "WANT_UPS" : {
+               "type" : "BOOL",
+               "value" : true
+            },
+            "lardataalg_EXEC_PREFIX_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FQ_DIR}"
+            },
+            "lardataalg_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
+               "type" : "STRING",
+               "value" : "cetmodules"
+            },
+            "lardataalg_UPS_PRODUCT_FLAVOR_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FLAVOR}"
+            },
+            "lardataalg_UPS_PRODUCT_NAME_INIT" : {
+               "type" : "STRING",
+               "value" : "lardataalg"
+            },
+            "lardataalg_UPS_QUALIFIER_STRING_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_QUALSPEC}"
+            }
+         },
+         "description" : "Extra configuration for UPS package generation",
+         "displayName" : "UPS extra configuration",
+         "hidden" : true,
+         "name" : "extra_for_UPS"
+      },
+      {
+         "description" : "Default configuration including settings from ups/product_deps",
+         "displayName" : "Default configuration",
+         "inherits" : "from_product_deps",
+         "name" : "default"
+      },
+      {
+         "description" : "Default configuration for UPS package generation",
+         "displayName" : "Default configuration for UPS",
+         "inherits" : [
+            "default",
+            "extra_for_UPS"
+         ],
+         "name" : "for_UPS"
+      }
+   ],
+   "version" : 3
+}

--- a/lardataalg/DetectorInfo/CMakeLists.txt
+++ b/lardataalg/DetectorInfo/CMakeLists.txt
@@ -1,20 +1,36 @@
-cet_make_library(
-         SOURCE DetectorClocksStandard.cxx
-                DetectorPropertiesData.cc
-                DetectorPropertiesStandard.cxx
-                ElecClock.cxx
-                LArPropertiesStandard.cxx
-                RunHistoryStandard.cxx
-         LIBRARIES
-                   canvas::canvas
-                   messagefacility::MF_MessageLogger
-                   cetlib_except::cetlib_except
-                   fhiclcpp::fhiclcpp
-                   ROOT::Core
-                   ROOT::Hist
-         PUBLIC    larcorealg::Geometry
-                   larcorealg::CoreUtils
-                   lardataobj::RawData
+cet_make_library(SOURCE
+  DetectorClocksStandard.cxx
+  DetectorPropertiesData.cc
+  DetectorPropertiesStandard.cxx
+  ElecClock.cxx
+  LArPropertiesStandard.cxx
+  RunHistoryStandard.cxx
+  LIBRARIES
+  PUBLIC
+  lardataobj::RawData
+  larcorealg::Geometry
+  larcoreobj::SimpleTypesAndConstants
+  canvas::canvas
+  messagefacility::MF_MessageLogger
+  fhiclcpp::types
+  fhiclcpp::fhiclcpp
+  cetlib_except::cetlib_except
+  PRIVATE
+  cetlib::cetlib
+  ROOT::Core
+  ROOT::Hist
+)
+
+cet_make_library(LIBRARY_NAME DetectorInfo_TestHelpers INTERFACE
+  SOURCE
+  DetectorClocksStandardTestHelpers.h
+  DetectorPropertiesStandardTestHelpers.h
+  LArPropertiesStandardTestHelpers.h
+  LIBRARIES INTERFACE
+  lardataalg::DetectorInfo
+  larcorealg::TestUtils
+  messagefacility::MF_MessageLogger
+  fhiclcpp::fhiclcpp
 )
 
 install_headers()

--- a/lardataalg/Dumpers/CMakeLists.txt
+++ b/lardataalg/Dumpers/CMakeLists.txt
@@ -1,4 +1,11 @@
-install_headers() 
-install_source() 
+cet_make_library(INTERFACE
+  SOURCE
+  DumperBase.h
+  RawData/OpDetWaveform.h
+  LIBRARIES INTERFACE
+  lardataalg::UtilitiesHeaders
+  lardataobj::headers
+)
 
-add_subdirectory(RawData)
+install_headers(SUBDIRS RawData)
+install_source(SUBDIRS RawData)

--- a/lardataalg/Dumpers/RawData/CMakeLists.txt
+++ b/lardataalg/Dumpers/RawData/CMakeLists.txt
@@ -1,2 +1,0 @@
-install_headers() 
-install_source() 

--- a/lardataalg/MCDumpers/CMakeLists.txt
+++ b/lardataalg/MCDumpers/CMakeLists.txt
@@ -1,10 +1,15 @@
-cet_make_library(
-  SOURCE MCDumperUtils.cxx
+cet_make_library(SOURCE
+  MCDumpers.h
+  MCDumperUtils.cxx
   LIBRARIES
-    nusimdata::SimulationBase
-    ROOT::EG
-    ROOT::Core
-  )
+  PUBLIC
+  larcorealg::geo_vectors_utils_TVector
+  nusimdata::SimulationBase
+  ROOT::Physics
+  PRIVATE
+  ${GENIE_LIB_LIST}
+  ROOT::EG
+)
 
 install_headers()
 install_source()

--- a/lardataalg/Utilities/CMakeLists.txt
+++ b/lardataalg/Utilities/CMakeLists.txt
@@ -1,19 +1,18 @@
-
-
 cet_make_library(LIBRARY_NAME UtilitiesHeaders INTERFACE
- SOURCE 
-    constexpr_math.h
-    intervals_fhicl.h
-    intervals.h
-    MappedContainer.h
-    MultipleChoiceSelection.h
-    quantities_fhicl.h
-    quantities.h
-    StatCollector.h
+  SOURCE
+  constexpr_math.h
+  intervals_fhicl.h
+  intervals.h
+  MappedContainer.h
+  MultipleChoiceSelection.h
+  quantities_fhicl.h
+  quantities.h
+  StatCollector.h
   LIBRARIES INTERFACE
-       larcorealg::CoreUtils
-       fhiclcpp::fhiclcpp
+  larcorealg::headers
+  fhiclcpp::fhiclcpp
+  Boost::headers
 )
 
-install_headers(SUBDIRS "quantities")
-install_source(SUBDIRS "quantities")
+install_headers(SUBDIRS quantities)
+install_source(SUBDIRS quantities)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,8 @@
-
 include(CetTest)
 cet_enable_asserts()
 
-add_subdirectory(DetectorInfo)
+find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+
 add_subdirectory(Utilities)
+add_subdirectory(DetectorInfo)
 

--- a/test/DetectorInfo/CMakeLists.txt
+++ b/test/DetectorInfo/CMakeLists.txt
@@ -1,11 +1,12 @@
-cet_test( LArPropertiesStandard_test
-  LIBRARIES
-  lardataalg_DetectorInfo
-  cetlib::cetlib
+cet_test(LArPropertiesStandard_test
   DATAFILES lartest_standard.fcl
   TEST_ARGS ./lartest_standard.fcl
   INSTALL_BIN
   INSTALL_SOURCE
+  LIBRARIES PRIVATE
+  lardataalg::DetectorInfo_TestHelpers
+  lardataalg::DetectorInfo
+  larcorealg::unit_test_base
 )
 
 cet_test( LArPropertiesLArTPCdetector_test
@@ -22,30 +23,36 @@ cet_test( LArPropertiesBo_test
   TEST_ARGS ./lartest_bo.fcl
 )
 
-
-cet_test( DetectorClocksStandard_test
-  LIBRARIES
-  lardataalg_DetectorInfo
-  cetlib::cetlib
+cet_test(DetectorClocksStandard_test
   DATAFILES clockstest_standard.fcl
   TEST_ARGS ./clockstest_standard.fcl
   INSTALL_BIN
   INSTALL_SOURCE
+  LIBRARIES PRIVATE
+  lardataalg::DetectorInfo_TestHelpers
+  lardataalg::DetectorInfo
+  larcorealg::TestUtils
 )
 
-cet_test( DetectorTimingTypes_test
-          LIBRARIES cetlib::cetlib
-                    lardataalg::UtilitiesHeaders
-          USE_BOOST_UNIT)
+cet_test(DetectorTimingTypes_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::disable_boost_fpc_tolerance
+  lardataalg::DetectorInfo
+  lardataalg::UtilitiesHeaders
+  larcorealg::CoreUtils
+)
 
-cet_test( DetectorTimingsStandard_test
-  LIBRARIES
-  lardataalg_DetectorInfo
-  cetlib::cetlib
+cet_test(DetectorTimingsStandard_test
   DATAFILES clockstest_standard.fcl
   TEST_ARGS ./clockstest_standard.fcl
   INSTALL_BIN
   INSTALL_SOURCE
+  LIBRARIES PRIVATE
+  lardataalg::DetectorInfo_TestHelpers
+  lardataalg::DetectorInfo
+  lardataalg::UtilitiesHeaders
+  larcorealg::CoreUtils
+  messagefacility::MF_MessageLogger
 )
 
 cet_test( DetectorClocksLArTPCdetector_test
@@ -69,10 +76,12 @@ cet_test( DetectorClocksCSU40L_test
   TEST_ARGS ./clockstest_csu40l.fcl
 )
 
-cet_make_exec( NAME DetectorPropertiesStandard_test
+cet_make_exec(NAME DetectorPropertiesStandard_test
   LIBRARIES PRIVATE
-  lardataalg_DetectorInfo
-  cetlib::cetlib
+  lardataalg::DetectorInfo_TestHelpers
+  lardataalg::DetectorInfo
+  larcorealg::geometry_unit_test_base
+  larcorealg::Geometry
 )
 
 cet_test( DetectorPropertiesLArTPCdetector_test

--- a/test/DetectorInfo/DetectorPropertiesStandard_test.cc
+++ b/test/DetectorInfo/DetectorPropertiesStandard_test.cc
@@ -13,7 +13,7 @@
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandard.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesStandardTestHelpers.h"
 #include "lardataalg/DetectorInfo/LArPropertiesStandardTestHelpers.h"
-#include "test/Geometry/geometry_unit_test_base.h"
+#include "larcorealg/TestUtils/geometry_unit_test_base.h"
 
 // C/C++ standard libraries
 #include <array>

--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -1,30 +1,81 @@
-cet_test(constexpr_math_test)
-cet_test(quantities_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
+cet_make_library(LIBRARY_NAME disable_boost_fpc_tolerance INTERFACE
+  USE_BOOST_UNIT NO_INSTALL
+  SOURCE disable_boost_fpc_tolerance.hpp
+  LIBRARIES INTERFACE
+  lardataalg::UtilitiesHeaders
+  Boost::unit_test_framework
+)
+
+cet_test(constexpr_math_test
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(quantities_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::disable_boost_fpc_tolerance
+  lardataalg::UtilitiesHeaders
+)
+
 cet_test(quantities_fhicl_test USE_BOOST_UNIT
   LIBRARIES PRIVATE
-    fhiclcpp::fhiclcpp
-    fhiclcpp::types
-    cetlib_except::cetlib_except
-    lardataalg::UtilitiesHeaders
-  )
-cet_test(intervals_test
-         LIBRARIES PRIVATE cetlib_except::cetlib_except
-                           lardataalg::UtilitiesHeaders
-         USE_BOOST_UNIT)
+  lardataalg::disable_boost_fpc_tolerance
+  lardataalg::UtilitiesHeaders
+  fhiclcpp::fhiclcpp
+  fhiclcpp::types
+  cetlib_except::cetlib_except
+)
+
+cet_test(intervals_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::disable_boost_fpc_tolerance
+  lardataalg::UtilitiesHeaders
+  larcorealg::CoreUtils
+)
+
 cet_test(intervals_fhicl_test USE_BOOST_UNIT
   LIBRARIES PRIVATE
-    fhiclcpp::fhiclcpp
-    fhiclcpp::types
-    cetlib_except::cetlib_except
-    lardataalg::UtilitiesHeaders
-  )
-cet_test(space_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
-cet_test(frequency_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
-cet_test(energy_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
-cet_test(datasize_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
-cet_test(StatCollector_test USE_BOOST_UNIT)
-cet_test(MappedContainer_test LIBRARIES lardataalg::UtilitiesHeaders USE_BOOST_UNIT)
-cet_test(MultipleChoiceSelection_test USE_BOOST_UNIT)
+  lardataalg::disable_boost_fpc_tolerance
+  lardataalg::UtilitiesHeaders
+  fhiclcpp::types
+  fhiclcpp::fhiclcpp
+)
+
+cet_test(space_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(frequency_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(energy_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(datasize_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(StatCollector_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
+
+cet_test(MappedContainer_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+  larcorealg::headers
+)
+
+cet_test(MultipleChoiceSelection_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE
+  lardataalg::UtilitiesHeaders
+)
 
 install_fhicl()
 install_source()

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,7 +249,7 @@ fcldir	product_dir	job
 product		version		qual	flags		<table_format=2>
 larcorealg	v09_06_02	-
 lardataobj	v09_06_03	-
-cetmodules	v3_09_03	-	only_for_build
+cetmodules	v3_12_00	-	only_for_build
 end_product_list
 ####################################
 


### PR DESCRIPTION
- Cetmodules -> 3.12.00
- Improve CMake use and tighten dependencies
- Presets generated by Cetmodules 3.12.00
