### PR TITLE
Updating absorption length to 80m for Xe wavelengths

### DIFF
--- a/lardataalg/DetectorInfo/larproperties.fcl
+++ b/lardataalg/DetectorInfo/larproperties.fcl
@@ -58,7 +58,7 @@ standard_properties:
 
  # absorption length as function of energy
  AbsLengthEnergies: [ 4,     5,     6,     7,     8,     9,     10,    11   ]
- AbsLengthSpectrum: [ 2000., 2000., 2000., 2000., 2000., 2000., 2000., 2000.]
+ AbsLengthSpectrum: [ 8000., 8000., 8000., 8000., 8000., 2000., 2000., 2000.]
 
  # Rayleigh scattering length (cm) @ 90K as a function of energy (eV) from arXiv:2002.09346
 


### PR DESCRIPTION
This PR updates the AbsLengthSpectrum to 80 meters (from 20 meters) for xenon wavelength light and above. This is the standard value used now in DUNE. This PR is needed for:

https://github.com/DUNE/duneopdet/pull/26
https://github.com/LArSoft/larsim/pull/115