### PR TITLE
MultipleChoiceSelection.h: added missing inline directives

### DIFF
--- a/lardataalg/Utilities/MultipleChoiceSelection.h
+++ b/lardataalg/Utilities/MultipleChoiceSelection.h
@@ -491,25 +491,25 @@ bool my_lexicographical_compare(B1 b1, E1 e1, B2 b2, E2 e2, Comp less)
   return true; // 1 is shorter
 } // my_lexicographical_compare()
 
-bool util::details::CaseInsensitiveComparer::equal(std::string const& a, std::string const& b)
+inline bool util::details::CaseInsensitiveComparer::equal(std::string const& a, std::string const& b)
 {
   return std::equal(a.begin(), a.end(), b.begin(), b.end(), eq_lower);
 }
 
 // -----------------------------------------------------------------------------
-bool util::details::CaseInsensitiveComparer::less(std::string const& a, std::string const& b)
+inline bool util::details::CaseInsensitiveComparer::less(std::string const& a, std::string const& b)
 {
   return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), cmp_lower);
 } // util::details::CaseInsensitiveComparer::less()
 
 // -----------------------------------------------------------------------------
-bool util::details::CaseInsensitiveComparer::cmp_lower(unsigned char a, unsigned char b)
+inline bool util::details::CaseInsensitiveComparer::cmp_lower(unsigned char a, unsigned char b)
 {
   return std::tolower(a) < std::tolower(b);
 }
 
 // -----------------------------------------------------------------------------
-bool util::details::CaseInsensitiveComparer::eq_lower(unsigned char a, unsigned char b)
+inline bool util::details::CaseInsensitiveComparer::eq_lower(unsigned char a, unsigned char b)
 {
   return std::tolower(a) == std::tolower(b);
 }

--- a/lardataalg/Utilities/MultipleChoiceSelection.h
+++ b/lardataalg/Utilities/MultipleChoiceSelection.h
@@ -491,7 +491,8 @@ bool my_lexicographical_compare(B1 b1, E1 e1, B2 b2, E2 e2, Comp less)
   return true; // 1 is shorter
 } // my_lexicographical_compare()
 
-inline bool util::details::CaseInsensitiveComparer::equal(std::string const& a, std::string const& b)
+inline bool util::details::CaseInsensitiveComparer::equal(std::string const& a,
+                                                          std::string const& b)
 {
   return std::equal(a.begin(), a.end(), b.begin(), b.end(), eq_lower);
 }


### PR DESCRIPTION
In the sea of templates, I had missed the few functions which were not templated and need to be declared `inline`.

It should fix linking problems in `icaruscode`.