### PR TITLE
Propagate to the collection plane when not accounting for the interplane timings in ticks<->x conversions

### DIFF
--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
@@ -374,11 +374,12 @@ namespace detinfo {
           const geo::PlaneGeo& pgeom = tpcgeom.Plane(plane);
 
           //Choose which plane to propagate to
-          //If accounting for the drift time between planes, start with the first plane, 
+          //If accounting for the drift time between planes, start with the first plane,
           //and iteratively add distances between planes
           //Otherwise propagate straight to the last plane and
           //assume a standard drift velocity (for wirecell recob::Wires)
-          unsigned int planeToPropagateTo = (fIncludeInterPlanePitchInXTickOffsets ? 0 : tpcgeom.Nplanes()-1);
+          unsigned int planeToPropagateTo =
+            (fIncludeInterPlanePitchInXTickOffsets ? 0 : tpcgeom.Nplanes() - 1);
           // Calculate geometric time offset.
           // only works if xyz[0]<=0
           auto const xyz = tpcgeom.Plane(planeToPropagateTo).GetCenter();

--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.cxx
@@ -373,9 +373,15 @@ namespace detinfo {
         for (int plane = 0; plane < nplane; ++plane) {
           const geo::PlaneGeo& pgeom = tpcgeom.Plane(plane);
 
+          //Choose which plane to propagate to
+          //If accounting for the drift time between planes, start with the first plane, 
+          //and iteratively add distances between planes
+          //Otherwise propagate straight to the last plane and
+          //assume a standard drift velocity (for wirecell recob::Wires)
+          unsigned int planeToPropagateTo = (fIncludeInterPlanePitchInXTickOffsets ? 0 : tpcgeom.Nplanes()-1);
           // Calculate geometric time offset.
           // only works if xyz[0]<=0
-          auto const xyz = tpcgeom.Plane(0).GetCenter();
+          auto const xyz = tpcgeom.Plane(planeToPropagateTo).GetCenter();
 
           x_ticks_offsets[cstat][tpc][plane] =
             -xyz.X() / (dir * x_ticks_coefficient) + triggerOffset;

--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
@@ -121,6 +121,8 @@ namespace detinfo {
                 "between the wire planes. This is appropriate for "
                 "recob::RawDigits, and recob::Wires from the 1D unfolding, "
                 "but is not appropriate for recob::Wires from WireCell. "
+                "When disabled, the conversion propgates to the last plane, "
+                "rather than the first plane and assumes a standard drift velocity. "
                 "The default value is 'true', retaining the 'classic' behaviour"),
         true};
 

--- a/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
+++ b/lardataalg/DetectorInfo/DetectorPropertiesStandard.h
@@ -121,7 +121,7 @@ namespace detinfo {
                 "between the wire planes. This is appropriate for "
                 "recob::RawDigits, and recob::Wires from the 1D unfolding, "
                 "but is not appropriate for recob::Wires from WireCell. "
-                "When disabled, the conversion propgates to the last plane, "
+                "When disabled, the conversion propagates to the last plane, "
                 "rather than the first plane and assumes a standard drift velocity. "
                 "The default value is 'true', retaining the 'classic' behaviour"),
         true};


### PR DESCRIPTION
By my count there are two flavours of recob::wires on the market: 
 - Those produced from the legacy 1D signal processings, that simply deconvolve the detector response from the raw digits.  This typically offsets the deconvolved waveforms from the raw waveforms by ~2us (shaping time dependent)
 - Those produced by the wirecell 2D signal processing.  The detector ticks associated with these recob::wires are formed assuming a uniform drift time to the collection plane, regardless of what plane they are on

A while back, we updated the detector properties service to optionally disable accounting for the interplane timing when doing ticks<->x conversions as those are not needed when dealing with wirecell recob::wires.

However, the relevant code still only propagated to plane 0 which would always be the first induction plane.  This results in a small offset of the reconstructed positions relative to the true positions when using wirecell's recob::wires

This PR changes the chosen propagation plane to the collection plane, but only when the accounting for the interplane timing is disabled.

(The PR is actually very small and the code is easier to understand than this explanation...)