### PR TITLE
util::MultipleChoiceSelection: removed unused private member

### DIFF
--- a/lardataalg/Utilities/MultipleChoiceSelection.h
+++ b/lardataalg/Utilities/MultipleChoiceSelection.h
@@ -399,10 +399,6 @@ private:
   /// Removes the specified label from the register.
   void unregisterLabel(std::string const& label);
 
-  /// Retrieves the option with the specified `value`.
-  /// @throw UnknownOptionError if there is no available option with `value`
-  Option_t& get(Choices_t value);
-
   /// Returns an iterator to the option with `label`, or `npos` if none.
   typename OptionList_t::const_iterator findOption(Choices_t value) const;
 
@@ -1007,17 +1003,6 @@ std::size_t util::MultipleChoiceSelection<Choices>::findOptionIndex(std::string 
   auto const iOption = fLabelToOptionIndex.find(label);
   return (iOption == fLabelToOptionIndex.end()) ? npos : iOption->second;
 } // util::MultipleChoiceSelection<>::findOptionIndex(string) const
-
-// -----------------------------------------------------------------------------
-template <typename Choices>
-auto util::MultipleChoiceSelection<Choices>::get(Choices_t value) -> Option_t&
-{
-  auto const iOption = findOption(value);
-  if (iOption == fOptions.end()) {
-    throw UnknownOptionError(Option_t::value_as_string(value).value_or(""));
-  }
-  return *iOption;
-} // util::MultipleChoiceSelection<>::get()
 
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Not only `util::MultipleChoiceSelection::get()` is unused, but it also comes in the way of the constant version of it, that is public. Given that it's a private member, this change won't affect any other code.