### PR TITLE
include cstdint for gcc 13.x

### DIFF
--- a/lardataalg/DetectorInfo/RunHistoryStandard.h
+++ b/lardataalg/DetectorInfo/RunHistoryStandard.h
@@ -9,6 +9,7 @@
 #ifndef DETINFO_RUNHISTORY_H
 #define DETINFO_RUNHISTORY_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Avoid undefined uint64_t errors in latest gcc, etc. 