### PR TITLE
Add the dumping of MCGeneratorInfo to the MCTruth dump

### DIFF
--- a/lardataalg/MCDumpers/MCDumpers.h
+++ b/lardataalg/MCDumpers/MCDumpers.h
@@ -343,7 +343,7 @@ void sim::dump::DumpMCTruth(Stream&& out,
 {
   // add a dumper of the generator info
   auto genInfo = truth.GeneratorInfo();
-  out << "Generator ID: " << genInfo.generator << "\n";
+  out << "Generator ID: " << (int) genInfo.generator << "\n";
   out << "Generator Version: " << genInfo.generatorVersion << "\n";
   out << "Generator configuration string map.  Pairs separated by colons. " << "\n";
   for (const auto& gci : genInfo.generatorConfig) {

--- a/lardataalg/MCDumpers/MCDumpers.h
+++ b/lardataalg/MCDumpers/MCDumpers.h
@@ -341,6 +341,15 @@ void sim::dump::DumpMCTruth(Stream&& out,
                             std::string indent,
                             std::string firstIndent)
 {
+  // add a dumper of the generator info
+  auto genInfo = truth.GeneratorInfo();
+  out << "Generator ID: " << genInfo.generator << "\n";
+  out << "Generator Version: " << genInfo.generatorVersion << "\n";
+  out << "Generator configuration string map.  Pairs separated by colons. " << "\n";
+  for (const auto& gci : genInfo.generatorConfig) {
+      out << "   " << gci.first << " : " << gci.second << "\n";
+    }
+
   unsigned int const nParticles = truth.NParticles();
   out << firstIndent << nParticles << " particles from " << TruthOriginName(truth.Origin());
   if (truth.NeutrinoSet()) {

--- a/lardataalg/MCDumpers/MCDumpers.h
+++ b/lardataalg/MCDumpers/MCDumpers.h
@@ -343,12 +343,13 @@ void sim::dump::DumpMCTruth(Stream&& out,
 {
   // add a dumper of the generator info
   auto genInfo = truth.GeneratorInfo();
-  out << "Generator ID: " << (int) genInfo.generator << "\n";
+  out << "Generator ID: " << (int)genInfo.generator << "\n";
   out << "Generator Version: " << genInfo.generatorVersion << "\n";
-  out << "Generator configuration string map.  Pairs separated by colons. " << "\n";
+  out << "Generator configuration string map.  Pairs separated by colons. "
+      << "\n";
   for (const auto& gci : genInfo.generatorConfig) {
-      out << "   " << gci.first << " : " << gci.second << "\n";
-    }
+    out << "   " << gci.first << " : " << gci.second << "\n";
+  }
 
   unsigned int const nParticles = truth.NParticles();
   out << firstIndent << nParticles << " particles from " << TruthOriginName(truth.Origin());


### PR DESCRIPTION
MCTruth has a MCGeneratorInfo struct in it that wasn't previously getting dumped when running dump_mctruth.fcl.  This PR adds dumping of the contents of that struct to the output stream.