### PR TITLE
MCParticle dumping new options for MCRecoEdep fixes [2/2]

### DIFF
--- a/lardataalg/MCDumpers/MCDumpers.h
+++ b/lardataalg/MCDumpers/MCDumpers.h
@@ -72,9 +72,13 @@ namespace sim {
      * @param trajectory the particle trajectory to be dumped
      * @param pointsPerLine number of points dumped per line (default: all)
      * @param indent base indentation string (default: none)
+     * @param printPosition prints space-time position on each trajectory point
+     * @param printMomentum prints momentum vector on each trajectory point
+     * @param printEnergy prints total energy on each trajectory point
      *
      * All points of the specified Monte Carlo `trajectory` are printed
-     * on screen, `pointsPerLine` on each line.
+     * on screen, `pointsPerLine` on each line. For each point, all the
+     * requested information is printed: position, then momentum, then energy.
      * The points are printed starting on a new line, and each line is applied
      * the same indentation string (`indent`).
      * As an exception, if `pointsPerLine` is not specified, all points are
@@ -86,7 +90,11 @@ namespace sim {
     void DumpMCParticleTrajectory(Stream&& out,
                                   simb::MCTrajectory const& trajectory,
                                   unsigned int pointsPerLine,
-                                  std::string indent);
+                                  std::string indent,
+                                  bool printPosition = true,
+                                  bool printMomentum = false,
+                                  bool printEnergy = false
+                                  );
 
     template <typename Stream>
     void DumpMCParticleTrajectory(Stream&& out, simb::MCTrajectory const& trajectory)
@@ -288,8 +296,42 @@ template <typename Stream>
 void sim::dump::DumpMCParticleTrajectory(Stream&& out,
                                          simb::MCTrajectory const& trajectory,
                                          unsigned int pointsPerLine,
-                                         std::string indent)
+                                         std::string indent,
+                                         bool printPosition /* = true */,
+                                         bool printMomentum /* = false */,
+                                         bool printEnergy /* = false */)
 {
+  
+  struct PointDumper {
+    
+    Stream& out;
+    bool const doPosition = true;
+    bool const doMomentum = true;
+    bool const doEnergy = true;
+    
+    void printPosition(TLorentzVector const& pos) const { out << pos << " cm"; }
+    void printEnergy(double E) const { out << "E=" << E << " GeV"; }
+    void printMomentum(TLorentzVector const& cp) const { out << "( " << cp.Px() << " , " << cp.Py() << " , " << cp.Pz() << " ) GeV/c"; }
+    
+    void operator() (std::pair<TLorentzVector, TLorentzVector> const& posAndMom) const
+      {
+        struct Spacer {
+          unsigned int nCalls = 0;
+          void operator() (Stream& out) { if (nCalls++) out << ", "; }
+        };
+        
+        Spacer spacer;
+        if (doPosition) { spacer(out); printPosition(posAndMom.first); }
+        if (doMomentum) { spacer(out); printMomentum(posAndMom.second); }
+        if (doEnergy)   { spacer(out); printEnergy(posAndMom.second.E()); }
+        if (spacer.nCalls == 0) out << '.'; // we promised we would print the point...
+      }
+    
+  }; // PointDumper
+  
+  
+  PointDumper const dumpPoint{ out, printPosition, printMomentum, printEnergy };
+  
   unsigned int page = 0;
   for (auto const& pair : trajectory) {
     if ((pointsPerLine > 0) && (page-- == 0)) {
@@ -299,8 +341,7 @@ void sim::dump::DumpMCParticleTrajectory(Stream&& out,
     else
       out << " -- ";
 
-    TLorentzVector const& pos = pair.first;
-    out << pos;
+    dumpPoint(pair);
   } // for trajectory points
 
 } // sim::dump::DumpMCParticleTrajectory()


### PR DESCRIPTION
`DumpMCParticleTrajectory()` is a simple algorithm printing information from a `sim::MCParticle` trajectory into a text stream.
With this modification, it can now optionally print momentum and energy along the trajectory.

The change is non-breaking as the new parameters are optional and defaults match the old behaviour (there _might_ be a slight difference in the text output though).

This PR is a dependency for PR LArSoft/larsim#152, where the MC particle dumper module uses the new interface.